### PR TITLE
Remove per-analysis logic from Ensemble

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ import autoapi
 from importlib.metadata import version
 
 # Define path to the code to be documented **relative to where conf.py (this file) is kept**
-sys.path.insert(0, os.path.abspath('../src/'))
+sys.path.insert(0, os.path.abspath("../src/"))
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -32,7 +32,7 @@ extensions.append("autoapi.extension")
 extensions.append("nbsphinx")
 
 templates_path = []
-exclude_patterns = ['_build', '**.ipynb_checkpoints']
+exclude_patterns = ["_build", "**.ipynb_checkpoints"]
 
 master_doc = "index"  # This assumes that sphinx-build is called from the root directory
 html_show_sourcelink = False  # Remove 'view source code' from top of page (for html, not python)

--- a/docs/notebooks/scaling_to_large_data.ipynb
+++ b/docs/notebooks/scaling_to_large_data.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -12,7 +11,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -22,7 +20,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -57,7 +54,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -78,7 +74,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -95,7 +90,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -134,7 +128,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -142,7 +135,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -176,7 +168,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -191,11 +182,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from tape.analysis.stetsonj import calc_stetson_J\n",
+    "from tape.analysis.stetsonj import calc_stetson_J, stetson_J_required_columns\n",
     "import numpy as np\n",
     "\n",
-    "mapres = ens.batch(calc_stetson_J, use_map=True)  # will not know to look at multiple partitions to get lightcurve data\n",
-    "groupres = ens.batch(calc_stetson_J, use_map=False)  # will know to look at multiple partitions, with shuffling costs\n",
+    "# Extract the mapping of columns to name strings.\n",
+    "column_map = ens.make_column_map()\n",
+    "\n",
+    "mapres = ens.batch(calc_stetson_J, *stetson_J_required_columns(column_map), use_map=True)  # will not know to look at multiple partitions to get lightcurve data\n",
+    "groupres = ens.batch(calc_stetson_J, *stetson_J_required_columns(column_map), use_map=False)  # will know to look at multiple partitions, with shuffling costs\n",
     "\n",
     "print(\"number of lightcurve results in mapres: \", len(mapres))\n",
     "print(\"number of lightcurve results in groupres: \", len(groupres))\n",
@@ -203,7 +197,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -220,7 +213,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/notebooks/working_with_structure_function.ipynb
+++ b/docs/notebooks/working_with_structure_function.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -16,7 +15,7 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "from tape.analysis.structurefunction2 import calc_sf2\n",
+    "from tape.analysis.structurefunction2 import calc_sf2, sf2_meta, sf2_required_columns\n",
     "\n",
     "from tape.analysis.structure_function.base_argument_container import StructureFunctionArgumentContainer\n",
     "from tape.analysis.structure_function.basic.calculator import BasicStructureFunctionCalculator\n",
@@ -28,7 +27,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -36,7 +34,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -64,7 +61,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -107,7 +103,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -130,7 +125,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -138,7 +132,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -220,7 +213,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -250,13 +242,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Because the `Ensemble` object can use arbitrary column names, we provide helper functions to generate the list of required columns (in the correct order) and meta data for the results. Both of these functions are located within analysis/structionfunction2.py."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Create the mapping of columns to name strings.\n",
+    "col_mapper = ens.make_column_map()\n",
+    "\n",
     "# Call batch on the ensemble providing no additional arguments.\n",
-    "res = ens.batch(calc_sf2, compute=True)\n",
+    "res = ens.batch(calc_sf2, *sf2_required_columns(col_mapper), meta=sf2_meta(), compute=True)\n",
     "res"
    ]
   },
@@ -274,7 +276,13 @@
     "arg_container.bin_method = \"loglength\"\n",
     "arg_container.bin_count_target = 40\n",
     "\n",
-    "res = ens.batch(calc_sf2, compute=True, argument_container=arg_container)\n",
+    "res = ens.batch(\n",
+    "    calc_sf2,\n",
+    "    *sf2_required_columns(col_mapper),\n",
+    "    meta=sf2_meta(),\n",
+    "    compute=True,\n",
+    "    argument_container=arg_container\n",
+    ")\n",
     "res"
    ]
   },
@@ -288,7 +296,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -335,7 +342,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -395,7 +401,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -416,7 +421,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -447,7 +451,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -491,7 +494,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -501,7 +503,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -530,7 +531,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -569,7 +569,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -625,7 +624,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -679,7 +677,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -738,7 +735,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/notebooks/working_with_the_ensemble.ipynb
+++ b/docs/notebooks/working_with_the_ensemble.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -9,7 +8,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -39,7 +37,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -47,7 +44,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -119,7 +115,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -334,7 +329,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -350,14 +344,17 @@
    "outputs": [],
    "source": [
     "# using tape analysis functions\n",
-    "from tape.analysis import calc_stetson_J\n",
+    "from tape.analysis import calc_stetson_J, stetson_J_required_columns\n",
     "\n",
-    "res = ens.batch(calc_stetson_J, compute=True)  # compute is set to true to execute immediately (non-lazily)\n",
+    "# Extract the mapping of columns to name strings.\n",
+    "column_map = ens.make_column_map()\n",
+    "\n",
+    "# compute is set to true to execute immediately (non-lazily)\n",
+    "res = ens.batch(calc_stetson_J, *stetson_J_required_columns(column_map), compute=True)\n",
     "res"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -423,6 +420,13 @@
    "source": [
     "ens.client.close()  # Tear down the ensemble client"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/src/tape/analysis/stetsonj.py
+++ b/src/tape/analysis/stetsonj.py
@@ -1,4 +1,26 @@
 import numpy as np
+from tape.utils import ColumnMapper
+
+
+def stetson_J_required_columns(column_mapper):
+    """Get a list of required columns for Stetson J.
+
+    Parameters
+    ----------
+    column_mapper: `ColumnMapper`
+        The object that provides a mapping from known column to name string.
+
+    Returns
+    -------
+    cols: list
+        A list of column names.
+    """
+    cols = [
+        column_mapper.lookup("flux_col"),
+        column_mapper.lookup("err_col"),
+        column_mapper.lookup("band_col"),
+    ]
+    return cols
 
 
 def calc_stetson_J(flux, err, band, band_to_calc=None, check_nans=True):

--- a/src/tape/analysis/structurefunction2.py
+++ b/src/tape/analysis/structurefunction2.py
@@ -5,6 +5,40 @@ import pandas as pd
 
 from tape.analysis.structure_function import SF_METHODS
 from tape.analysis.structure_function.sf_light_curve import StructureFunctionLightCurve
+from tape.utils import ColumnMapper
+
+
+def sf2_required_columns(column_mapper):
+    """Get a list of required columns for the structure function.
+
+    Parameters
+    ----------
+    column_mapper: `ColumnMapper`
+        The object that provides a mapping from known column to name string.
+
+    Returns
+    -------
+    cols: list
+        A list of column names.
+    """
+    cols = [
+        column_mapper.lookup("time_col"),
+        column_mapper.lookup("flux_col"),
+        column_mapper.lookup("err_col"),
+        column_mapper.lookup("band_col"),
+        column_mapper.lookup("id_col"),
+    ]
+    return cols
+
+
+def sf2_meta():
+    """Return the meta data for the sf2 result.
+
+    Returns
+    -------
+    A dictionary mapping result column name to type.
+    """
+    return {"lc_id": "int", "band": "str", "dt": "float", "sf2": "float", "1_sigma": "float"}
 
 
 def calc_sf2(time, flux, err=None, band=None, lc_id=None, sf_method="basic", argument_container=None):

--- a/src/tape/utils/column_mapper/column_mapper.py
+++ b/src/tape/utils/column_mapper/column_mapper.py
@@ -78,6 +78,20 @@ class ColumnMapper:
     def map_id() -> str:
         return None
 
+    def lookup(self, col):
+        """Look up the mapping for a column name.
+
+        Parameters
+        ----------
+        col: `str`
+            The column to lookup.
+
+        Returns
+        -------
+        A string with the column name or None.
+        """
+        return self.map[col]
+
     def use_known_map(self, map_id):
         """Use a known mapping scheme
 


### PR DESCRIPTION
This PR is to start discussion. I would like to remove as much of the per-analysis logic as possible from the `Ensemble` class. This represents one possible way to do this, but I'm not sure it is the best.

Create helper functions to provide the required columns (args) and meta for each analysis. Use `ColumnMapper` to link these back to the correct columns in the `Ensemble`. This requires that the user does a little more set up to run the analysis.