### PR TITLE
downgrade numpy for numba support

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,5 +6,5 @@ ipython
 jupytext
 jupyter
 matplotlib
-numpy==1.24.0
+numpy==1.23.5
 eztao

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,5 +6,5 @@ ipython
 jupytext
 jupyter
 matplotlib
-numpy
+numpy==1.24.0
 eztao

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,5 +6,4 @@ ipython
 jupytext
 jupyter
 matplotlib
-numpy==1.23.5
 eztao

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dynamic=["version"]
 dependencies = [
     'pandas',
-    'numpy',
+    'numpy<=1.23.5',
     'dask>=2023.5.0',
     'dask[distributed]',
     'pyarrow',


### PR DESCRIPTION
readthedocs has been failing builds since the sf showcase notebook went in (slightly concerning that our CI didn't catch this), at least one layer of this is that Numba needs Numpy <= 1.24.0, updated that for the docs requirements.