### PR TITLE
SF^1 to SF^2 bug fix

### DIFF
--- a/src/tape/analysis/structure_function/bauer_2009a/calculator.py
+++ b/src/tape/analysis/structure_function/bauer_2009a/calculator.py
@@ -10,6 +10,8 @@ class Bauer2009AStructureFunctionCalculator(StructureFunctionCalculator):
 
     `SF(tau) = sqrt( mean(delta_flux^2) - mean(err^2) )`
 
+    Note that the return value is structure function squared.
+
     Additional references:
     Graham et al. 2014MNRAS.439..703G [https://arxiv.org/abs/1401.1785]
     """
@@ -23,8 +25,8 @@ class Bauer2009AStructureFunctionCalculator(StructureFunctionCalculator):
         values_to_be_binned = [lc.sample_sum_squared_error for lc in self._lightcurves]
         _, mean_err2_per_bin = self._calculate_binned_statistics(sample_values=values_to_be_binned)
 
-        # calculate the structure function
-        sfs = np.sqrt(np.asarray(mean_d_flux_per_bin) - np.asarray(mean_err2_per_bin))
+        # calculate the structure function squared
+        sfs = np.asarray(mean_d_flux_per_bin) - np.asarray(mean_err2_per_bin)
 
         return dts, sfs
 

--- a/src/tape/analysis/structure_function/bauer_2009a/calculator.py
+++ b/src/tape/analysis/structure_function/bauer_2009a/calculator.py
@@ -10,8 +10,6 @@ class Bauer2009AStructureFunctionCalculator(StructureFunctionCalculator):
 
     `SF(tau) = sqrt( mean(delta_flux^2) - mean(err^2) )`
 
-    Note that the return value is structure function squared.
-
     Additional references:
     Graham et al. 2014MNRAS.439..703G [https://arxiv.org/abs/1401.1785]
     """
@@ -25,8 +23,8 @@ class Bauer2009AStructureFunctionCalculator(StructureFunctionCalculator):
         values_to_be_binned = [lc.sample_sum_squared_error for lc in self._lightcurves]
         _, mean_err2_per_bin = self._calculate_binned_statistics(sample_values=values_to_be_binned)
 
-        # calculate the structure function squared
-        sfs = np.asarray(mean_d_flux_per_bin) - np.asarray(mean_err2_per_bin)
+        # calculate the structure function
+        sfs = np.sqrt(np.asarray(mean_d_flux_per_bin) - np.asarray(mean_err2_per_bin))
 
         return dts, sfs
 

--- a/src/tape/analysis/structure_function/bauer_2009b/calculator.py
+++ b/src/tape/analysis/structure_function/bauer_2009b/calculator.py
@@ -12,8 +12,6 @@ class Bauer2009BStructureFunctionCalculator(StructureFunctionCalculator):
 
     `SF(tau) = sqrt( (pi/2) * mean(abs(delta_flux))^2 - mean(err^2) )`
 
-    Note that the return value is structure function squared.
-
     Additional references:
     Graham et al. 2014MNRAS.439..703G [https://arxiv.org/abs/1401.1785]
     """
@@ -27,8 +25,8 @@ class Bauer2009BStructureFunctionCalculator(StructureFunctionCalculator):
         values_to_be_binned = [lc.sample_sum_squared_error for lc in self._lightcurves]
         _, mean_err2_per_bin = self._calculate_binned_statistics(sample_values=values_to_be_binned)
 
-        # calculate the structure function squared
-        sfs = PI_OVER_2 * np.square(mean_d_flux_per_bin) - mean_err2_per_bin
+        # calculate the structure function
+        sfs = np.sqrt(PI_OVER_2 * np.square(mean_d_flux_per_bin) - mean_err2_per_bin)
 
         return dts, sfs
 

--- a/src/tape/analysis/structure_function/bauer_2009b/calculator.py
+++ b/src/tape/analysis/structure_function/bauer_2009b/calculator.py
@@ -12,6 +12,8 @@ class Bauer2009BStructureFunctionCalculator(StructureFunctionCalculator):
 
     `SF(tau) = sqrt( (pi/2) * mean(abs(delta_flux))^2 - mean(err^2) )`
 
+    Note that the return value is structure function squared.
+
     Additional references:
     Graham et al. 2014MNRAS.439..703G [https://arxiv.org/abs/1401.1785]
     """
@@ -26,7 +28,7 @@ class Bauer2009BStructureFunctionCalculator(StructureFunctionCalculator):
         _, mean_err2_per_bin = self._calculate_binned_statistics(sample_values=values_to_be_binned)
 
         # calculate the structure function
-        sfs = np.sqrt(PI_OVER_2 * np.square(mean_d_flux_per_bin) - mean_err2_per_bin)
+        sfs = PI_OVER_2 * np.square(mean_d_flux_per_bin) - mean_err2_per_bin
 
         return dts, sfs
 

--- a/src/tape/analysis/structure_function/bauer_2009b/calculator.py
+++ b/src/tape/analysis/structure_function/bauer_2009b/calculator.py
@@ -12,6 +12,8 @@ class Bauer2009BStructureFunctionCalculator(StructureFunctionCalculator):
 
     `SF(tau) = sqrt( (pi/2) * mean(abs(delta_flux))^2 - mean(err^2) )`
 
+    Note that the return value is structure function squared.
+
     Additional references:
     Graham et al. 2014MNRAS.439..703G [https://arxiv.org/abs/1401.1785]
     """
@@ -25,8 +27,8 @@ class Bauer2009BStructureFunctionCalculator(StructureFunctionCalculator):
         values_to_be_binned = [lc.sample_sum_squared_error for lc in self._lightcurves]
         _, mean_err2_per_bin = self._calculate_binned_statistics(sample_values=values_to_be_binned)
 
-        # calculate the structure function
-        sfs = np.sqrt(PI_OVER_2 * np.square(mean_d_flux_per_bin) - mean_err2_per_bin)
+        # calculate the structure function squared
+        sfs = PI_OVER_2 * np.square(mean_d_flux_per_bin) - mean_err2_per_bin
 
         return dts, sfs
 

--- a/src/tape/analysis/structure_function/macleod_2012/calculator.py
+++ b/src/tape/analysis/structure_function/macleod_2012/calculator.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import numpy as np
 
 from tape.analysis.structure_function.base_argument_container import StructureFunctionArgumentContainer
@@ -18,6 +16,8 @@ class Macleod2012StructureFunctionCalculator(StructureFunctionCalculator):
 
     Where `IQR` is the interquartile range between 25% and 75% of the sorted
     (y(t) - y(t+delta_t)) distribution.
+
+    Note that the return value is structure function squared.
 
     Additional references:
     Kozlowski 2016, 2016ApJ...826..118K [https://arxiv.org/abs/1604.05858]
@@ -47,7 +47,7 @@ class Macleod2012StructureFunctionCalculator(StructureFunctionCalculator):
         # calculate interquartile range between 25% and 75%.
         iqr = np.subtract(*np.percentile(input, [75, 25]))
 
-        return CONVERSION_TO_SIGMA * iqr
+        return (CONVERSION_TO_SIGMA * iqr)**2
 
     @staticmethod
     def name_id() -> str:

--- a/src/tape/analysis/structure_function/macleod_2012/calculator.py
+++ b/src/tape/analysis/structure_function/macleod_2012/calculator.py
@@ -19,8 +19,6 @@ class Macleod2012StructureFunctionCalculator(StructureFunctionCalculator):
     Where `IQR` is the interquartile range between 25% and 75% of the sorted
     (y(t) - y(t+delta_t)) distribution.
 
-    Note that the return value is structure function squared.
-
     Additional references:
     Kozlowski 2016, 2016ApJ...826..118K [https://arxiv.org/abs/1604.05858]
     """
@@ -49,7 +47,7 @@ class Macleod2012StructureFunctionCalculator(StructureFunctionCalculator):
         # calculate interquartile range between 25% and 75%.
         iqr = np.subtract(*np.percentile(input, [75, 25]))
 
-        return (CONVERSION_TO_SIGMA * iqr)**2
+        return CONVERSION_TO_SIGMA * iqr
 
     @staticmethod
     def name_id() -> str:

--- a/src/tape/analysis/structure_function/macleod_2012/calculator.py
+++ b/src/tape/analysis/structure_function/macleod_2012/calculator.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import numpy as np
 
 from tape.analysis.structure_function.base_argument_container import StructureFunctionArgumentContainer

--- a/src/tape/analysis/structure_function/macleod_2012/calculator.py
+++ b/src/tape/analysis/structure_function/macleod_2012/calculator.py
@@ -47,7 +47,7 @@ class Macleod2012StructureFunctionCalculator(StructureFunctionCalculator):
         # calculate interquartile range between 25% and 75%.
         iqr = np.subtract(*np.percentile(input, [75, 25]))
 
-        return (CONVERSION_TO_SIGMA * iqr)**2
+        return (CONVERSION_TO_SIGMA * iqr) ** 2
 
     @staticmethod
     def name_id() -> str:

--- a/src/tape/analysis/structure_function/schmidt_2010/calculator.py
+++ b/src/tape/analysis/structure_function/schmidt_2010/calculator.py
@@ -24,6 +24,7 @@ class Schmidt2010StructureFunctionCalculator(StructureFunctionCalculator):
         ]
 
         dts, sfs = self._calculate_binned_statistics(sample_values=values_to_be_binned)
+        sfs = [i**2 for i in sfs]
 
         return dts, sfs
 

--- a/src/tape/analysis/structure_function/schmidt_2010/calculator.py
+++ b/src/tape/analysis/structure_function/schmidt_2010/calculator.py
@@ -13,8 +13,6 @@ class Schmidt2010StructureFunctionCalculator(StructureFunctionCalculator):
 
     `SF(delta_t) = mean(sqrt(pi/2) * abs(delta_flux_i,j) - sqrt(err_i^2 + err_j^2))`
 
-    Note that the return value is structure function squared.
-
     Additional references:
     Graham et al. 2014MNRAS.439..703G [https://arxiv.org/abs/1401.1785]
     """
@@ -27,7 +25,7 @@ class Schmidt2010StructureFunctionCalculator(StructureFunctionCalculator):
 
         dts, sfs = self._calculate_binned_statistics(sample_values=values_to_be_binned)
 
-        return dts, sfs**2
+        return dts, sfs
 
     @staticmethod
     def name_id() -> str:

--- a/src/tape/analysis/structure_function/schmidt_2010/calculator.py
+++ b/src/tape/analysis/structure_function/schmidt_2010/calculator.py
@@ -13,6 +13,8 @@ class Schmidt2010StructureFunctionCalculator(StructureFunctionCalculator):
 
     `SF(delta_t) = mean(sqrt(pi/2) * abs(delta_flux_i,j) - sqrt(err_i^2 + err_j^2))`
 
+    Note that the return value is structure function squared.
+
     Additional references:
     Graham et al. 2014MNRAS.439..703G [https://arxiv.org/abs/1401.1785]
     """
@@ -24,7 +26,7 @@ class Schmidt2010StructureFunctionCalculator(StructureFunctionCalculator):
         ]
 
         dts, sfs = self._calculate_binned_statistics(sample_values=values_to_be_binned)
-        sfs = [i**2 for i in sfs]
+        sfs = [i ** 2 for i in sfs]
 
         return dts, sfs
 

--- a/src/tape/analysis/structure_function/schmidt_2010/calculator.py
+++ b/src/tape/analysis/structure_function/schmidt_2010/calculator.py
@@ -26,7 +26,7 @@ class Schmidt2010StructureFunctionCalculator(StructureFunctionCalculator):
         ]
 
         dts, sfs = self._calculate_binned_statistics(sample_values=values_to_be_binned)
-        sfs = [i ** 2 for i in sfs]
+        sfs = [i**2 for i in sfs]
 
         return dts, sfs
 

--- a/src/tape/analysis/structure_function/schmidt_2010/calculator.py
+++ b/src/tape/analysis/structure_function/schmidt_2010/calculator.py
@@ -13,6 +13,8 @@ class Schmidt2010StructureFunctionCalculator(StructureFunctionCalculator):
 
     `SF(delta_t) = mean(sqrt(pi/2) * abs(delta_flux_i,j) - sqrt(err_i^2 + err_j^2))`
 
+    Note that the return value is structure function squared.
+
     Additional references:
     Graham et al. 2014MNRAS.439..703G [https://arxiv.org/abs/1401.1785]
     """
@@ -25,7 +27,7 @@ class Schmidt2010StructureFunctionCalculator(StructureFunctionCalculator):
 
         dts, sfs = self._calculate_binned_statistics(sample_values=values_to_be_binned)
 
-        return dts, sfs
+        return dts, sfs**2
 
     @staticmethod
     def name_id() -> str:

--- a/tests/tape_tests/structure_function_calculators/test_bauer_2009a_calculator.py
+++ b/tests/tape_tests/structure_function_calculators/test_bauer_2009a_calculator.py
@@ -42,4 +42,4 @@ def test_sf2_base_case_bauer_2009a():
     )
 
     assert res["dt"][0] == pytest.approx(3.1482, rel=0.001)
-    assert res["sf2"][0] == pytest.approx(0.0054, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.00536539, rel=0.001)

--- a/tests/tape_tests/structure_function_calculators/test_bauer_2009a_calculator.py
+++ b/tests/tape_tests/structure_function_calculators/test_bauer_2009a_calculator.py
@@ -42,4 +42,4 @@ def test_sf2_base_case_bauer_2009a():
     )
 
     assert res["dt"][0] == pytest.approx(3.1482, rel=0.001)
-    assert res["sf2"][0] == pytest.approx(0.0732, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.0054, rel=0.001)

--- a/tests/tape_tests/structure_function_calculators/test_bauer_2009b_calculator.py
+++ b/tests/tape_tests/structure_function_calculators/test_bauer_2009b_calculator.py
@@ -42,4 +42,4 @@ def test_sf2_base_case_bauer_2009b():
     )
 
     assert res["dt"][0] == pytest.approx(3.1482, rel=0.001)
-    assert res["sf2"][0] == pytest.approx(0.0226, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.0225667, rel=0.001)

--- a/tests/tape_tests/structure_function_calculators/test_bauer_2009b_calculator.py
+++ b/tests/tape_tests/structure_function_calculators/test_bauer_2009b_calculator.py
@@ -42,4 +42,4 @@ def test_sf2_base_case_bauer_2009b():
     )
 
     assert res["dt"][0] == pytest.approx(3.1482, rel=0.001)
-    assert res["sf2"][0] == pytest.approx(0.1502, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.0226, rel=0.001)

--- a/tests/tape_tests/structure_function_calculators/test_macleod_2012_calculator.py
+++ b/tests/tape_tests/structure_function_calculators/test_macleod_2012_calculator.py
@@ -52,4 +52,4 @@ def test_calculate_macleod_2012_method():
     # 0.74 * (75th - 25th) = 3.33
     output = sf_calculator.calculate_iqr_sf2_statistic(test_input)
 
-    assert output == 3.33
+    assert output == 11.0889

--- a/tests/tape_tests/structure_function_calculators/test_schmidt_2010_calculator.py
+++ b/tests/tape_tests/structure_function_calculators/test_schmidt_2010_calculator.py
@@ -42,4 +42,4 @@ def test_sf2_base_case_schmidt_2010():
     )
 
     assert res["dt"][0] == pytest.approx(3.1482, rel=0.001)
-    assert res["sf2"][0] == pytest.approx(0.1714, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.0294, rel=0.001)

--- a/tests/tape_tests/structure_function_calculators/test_schmidt_2010_calculator.py
+++ b/tests/tape_tests/structure_function_calculators/test_schmidt_2010_calculator.py
@@ -42,4 +42,4 @@ def test_sf2_base_case_schmidt_2010():
     )
 
     assert res["dt"][0] == pytest.approx(3.1482, rel=0.001)
-    assert res["sf2"][0] == pytest.approx(0.0294, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.02936347, rel=0.001)

--- a/tests/tape_tests/test_analysis.py
+++ b/tests/tape_tests/test_analysis.py
@@ -556,7 +556,7 @@ def test_sf2_base_case_macleod_2012():
     )
 
     assert res["dt"][0] == pytest.approx(3.1482, rel=0.001)
-    assert res["sf2"][0] == pytest.approx(0.4107, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.1687, rel=0.001)
 
 
 def test_sf2_multiple_bands():


### PR DESCRIPTION
Fixes https://github.com/lincc-frameworks/tape/issues/165, makes all calculators to return SF^2, instead of SF^1 for ``non-basic'' calculators. 