### PR TITLE
update default meta

### DIFF
--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -648,7 +648,7 @@ class Ensemble:
             meta = known_meta[func.__name__]
 
         if meta is None:
-            meta = (self._id_col, type(self._id_col))  # return a series of ids
+            meta = (self._id_col, float)  # return a series of ids, default assume a float is returned
 
         if on is None:
             on = self._id_col  # Default grouping is by id_col


### PR DESCRIPTION
The smoke tests started failing a few days ago. The culprit was the calc_stetson_J function, which returns a dictionary, was interacting poorly with the default meta assigned by ens.batch(). The default meta took the index columns string type and projects that onto the result, turning the dictionary into a string. In the long term, we should have calc_stetson_J return an object that is able to be coerced into a dataframe (maybe it already is?), but for now the meta assignment that defaults to the type of the ID column is probably not ideal, and we should instead expect floats as a general result.