### PR TITLE
Fix how Ensemble.batch processes on=None/str

### DIFF
--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -728,6 +728,8 @@ class Ensemble:
 
         if on is None:
             on = self._id_col  # Default grouping is by id_col
+        if isinstance(on, str):
+            on = [on]  # Convert to list if only one column is passed
 
         # Handle object columns to group on
         source_cols = list(self._source.columns)


### PR DESCRIPTION
This is a quick fix of a little bug in `Ensemble.batch`. However it would be nice to have better test coverage for `on` argument, which this PR does not provide

Closes #202