### PR TITLE
enable clientless ensemble

### DIFF
--- a/docs/tutorials/scaling_to_large_data.ipynb
+++ b/docs/tutorials/scaling_to_large_data.ipynb
@@ -28,9 +28,9 @@
    "source": [
     "### The `Dask` Client and Scheduler\n",
     "\n",
-    "An important aspect of `Dask` to understand for optimizing it's performance for large datasets is the Client. `Dask` has [thorough documentation](https://distributed.dask.org/en/stable/client.html) on this, but the general idea is that the Client is an interface for sending instructions to a Scheduler, which in turn coordinates the worker nodes in executing the intended workflow. In essence, the Client gives you control over how to parallelize your workflow.\n",
+    "An important aspect of `Dask` to understand for optimizing it's performance for large datasets is the Distributed Client. `Dask` has [thorough documentation](https://distributed.dask.org/en/stable/client.html) on this, but the general idea is that the Distributed Client is the entrypoint for setting up a distributed system. The Distributed Client enables asynchronous computation, where Dask's `compute` and `persist` methods are able to run in the background and persist in memory while we continue doing other work.\n",
     "\n",
-    "In the TAPE `Ensemble`, a default client in the background, which can be accessed using `Ensemble.client_info()`:\n",
+    "In the TAPE `Ensemble`, by default a Distributed Client is spun up in the background, which can be accessed using `Ensemble.client_info()`:\n",
     "\n"
    ]
   },
@@ -139,6 +139,23 @@
    "metadata": {},
    "source": [
     "This may be preferable for those who want full control of the `Dask` client API, which may be beneficial when working on external machines/services or when a more complex setup is desired."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, there may be instances where you would prefer to not use the Distributed Client, particularly when working with smaller amounts of data. In these instances, we allow users to disable the creation of a Distributed Client by passing `client=False`, as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ens=Ensemble(client=False)"
    ]
   },
   {

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -1,14 +1,11 @@
 import glob
 import os
-import time
 import warnings
-import json
 import requests
 
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
-import pyvo as vo
 from dask.distributed import Client
 
 from .analysis.base import AnalysisFunction
@@ -22,7 +19,18 @@ from .utils import ColumnMapper
 class Ensemble:
     """Ensemble object is a collection of light curve ids"""
 
-    def __init__(self, client=None, **kwargs):
+    def __init__(self, client=True, **kwargs):
+        """Constructor of an Ensemble instance.
+
+        Parameters
+        ----------
+        client: `dask.distributed.client` or `bool`, optional
+            Accepts an existing `dask.distributed.Client`, or creates one if
+            `client=True`, passing any additional kwargs to a
+             dask.distributed.Client constructor call. If `client=False`, the
+             Ensemble is created without a distributed client.
+
+        """
         self.result = None  # holds the latest query
 
         self._source = None  # Source Table
@@ -49,10 +57,12 @@ class Ensemble:
 
         self.client = None
         self.cleanup_client = False
-        # Setup Dask Distributed Client
-        if client:
+
+        # Setup Dask Distributed Client if Provided
+        if isinstance(client, Client):
             self.client = client
-        else:
+            self.cleanup_client = True
+        elif client:
             self.client = Client(**kwargs)  # arguments passed along to Client
             self.cleanup_client = True
 

--- a/tests/tape_tests/conftest.py
+++ b/tests/tape_tests/conftest.py
@@ -16,7 +16,25 @@ def dask_client():
 
 # pylint: disable=redefined-outer-name
 @pytest.fixture
-def parquet_ensemble(dask_client):
+def parquet_ensemble():
+    """Create an Ensemble from parquet data."""
+    ens = Ensemble(client=False)
+    ens.from_parquet(
+        "tests/tape_tests/data/source/test_source.parquet",
+        "tests/tape_tests/data/object/test_object.parquet",
+        id_col="ps1_objid",
+        time_col="midPointTai",
+        band_col="filterName",
+        flux_col="psFlux",
+        err_col="psFluxErr",
+    )
+
+    return ens
+
+
+# pylint: disable=redefined-outer-name
+@pytest.fixture
+def parquet_ensemble_with_client(dask_client):
     """Create an Ensemble from parquet data."""
     ens = Ensemble(client=dask_client)
     ens.from_parquet(
@@ -34,9 +52,9 @@ def parquet_ensemble(dask_client):
 
 # pylint: disable=redefined-outer-name
 @pytest.fixture
-def parquet_ensemble_from_source(dask_client):
+def parquet_ensemble_from_source():
     """Create an Ensemble from parquet data, with object file withheld."""
-    ens = Ensemble(client=dask_client)
+    ens = Ensemble(client=False)
     ens.from_parquet(
         "tests/tape_tests/data/source/test_source.parquet",
         id_col="ps1_objid",
@@ -51,9 +69,9 @@ def parquet_ensemble_from_source(dask_client):
 
 # pylint: disable=redefined-outer-name
 @pytest.fixture
-def parquet_ensemble_with_column_mapper(dask_client):
+def parquet_ensemble_with_column_mapper():
     """Create an Ensemble from parquet data, with object file withheld."""
-    ens = Ensemble(client=dask_client)
+    ens = Ensemble(client=False)
 
     colmap = ColumnMapper().assign(
         id_col="ps1_objid",
@@ -72,9 +90,9 @@ def parquet_ensemble_with_column_mapper(dask_client):
 
 # pylint: disable=redefined-outer-name
 @pytest.fixture
-def parquet_ensemble_with_known_column_mapper(dask_client):
+def parquet_ensemble_with_known_column_mapper():
     """Create an Ensemble from parquet data, with object file withheld."""
-    ens = Ensemble(client=dask_client)
+    ens = Ensemble(client=False)
 
     colmap = ColumnMapper().use_known_map("ZTF")
     ens.from_parquet(
@@ -87,9 +105,9 @@ def parquet_ensemble_with_known_column_mapper(dask_client):
 
 # pylint: disable=redefined-outer-name
 @pytest.fixture
-def parquet_ensemble_from_hipscat(dask_client):
+def parquet_ensemble_from_hipscat():
     """Create an Ensemble from a hipscat/hive-style directory."""
-    ens = Ensemble(client=dask_client)
+    ens = Ensemble(client=False)
     ens.from_hipscat(
         "tests/tape_tests/data",
         id_col="ps1_objid",

--- a/tests/tape_tests/test_analysis.py
+++ b/tests/tape_tests/test_analysis.py
@@ -10,7 +10,7 @@ from tape.analysis.structure_function.base_argument_container import StructureFu
 
 
 @pytest.mark.parametrize("cls", analysis.AnalysisFunction.__subclasses__())
-def test_analysis_function(cls, dask_client):
+def test_analysis_function(cls):
     """
     Test AnalysisFunction child classes
     """
@@ -28,7 +28,7 @@ def test_analysis_function(cls, dask_client):
         "flux": [1.0, 2.0, 5.0, 3.0, 1.0, 2.0, 3.0, 4.0, 5.0],
     }
     cmap = ColumnMapper(id_col="id", time_col="time", flux_col="flux", err_col="err", band_col="band")
-    ens = Ensemble(client=dask_client).from_source_dict(rows, column_mapper=cmap)
+    ens = Ensemble(client=False).from_source_dict(rows, column_mapper=cmap)
 
     assert isinstance(obj.cols(ens), list)
     assert len(obj.cols(ens)) > 0

--- a/tests/tape_tests/test_feature_extraction.py
+++ b/tests/tape_tests/test_feature_extraction.py
@@ -25,7 +25,7 @@ def test_stetsonk():
     assert_array_equal(result.dtypes, np.float64)
 
 
-def test_stetsonk_with_ensemble(dask_client):
+def test_stetsonk_with_ensemble():
     n = 5
 
     object1 = {
@@ -45,7 +45,7 @@ def test_stetsonk_with_ensemble(dask_client):
     rows = {column: np.concatenate([object1[column], object2[column]]) for column in object1}
 
     cmap = ColumnMapper(id_col="id", time_col="time", flux_col="flux", err_col="err", band_col="band")
-    ens = Ensemble(dask_client).from_source_dict(rows, cmap)
+    ens = Ensemble(client=False).from_source_dict(rows, cmap)
 
     stetson_k = licu.Extractor(licu.AndersonDarlingNormal(), licu.InterPercentileRange(0.25), licu.StetsonK())
     result = ens.batch(


### PR DESCRIPTION
Addresses #211. The unit test suite has been largely changed to not use a client, except for a few functions with additionally test the parquet_ensemble_with_client fixture. I have some concern about shifting many of our tests off of the distributed client, but it's possible that just using a subset of the test suite to cover distributed behavior in localized workflows will be sufficient. Since @hombit mentioned one of the pain points of the forced client was firewall permissions spam during the unit test suite execution, this implementation would allow for the small client subset to be excluding using this pytest incantation: `pytest -k "not with_client" `

I was originally trying to find a way to make a custom pytest flag that could switch the whole test suite from using the dask client or not, with the ambition to add client tests and clientless tests as two separate runs per python version in our github actions workflows. But I didn't have much luck parsing the pytest docs to understand how feasible this was.