### PR TITLE
Preserve EnsembleFrame metadata after assign()

### DIFF
--- a/src/tape/ensemble_frame.py
+++ b/src/tape/ensemble_frame.py
@@ -44,6 +44,32 @@ class _Frame(dd.core._Frame):
     def copy(self):
         self_copy = super().copy()
         return self._propagate_metadata(self_copy)
+    
+    def assign(self, **kwargs):
+        """Assign new columns to a DataFrame.
+
+        This docstring was copied from dask.dataframe.DataFrame.assign.
+
+        Some inconsistencies with the Dask version may exist.
+
+        Returns a new object with all original columns in addition to new ones. Existing columns
+        that are re-assigned will be overwritten.
+
+        Parameters
+        ----------
+        **kwargs: `dict`
+            The column names are keywords. If the values are callable, they are computed on the
+            DataFrame and assigned to the new columns. The callable must not change input DataFrame
+            (though pandas doesn’t check it). If the values are not callable, (e.g. a Series,
+            scalar, or array), they are simply assigned.
+
+        Returns
+        ----------
+        result: `tape._Frame`
+            The modifed frame
+        """
+        result = super().assign(**kwargs)
+        return self._propagate_metadata(result)
 
 class TapeSeries(pd.Series):
     """A barebones extension of a Pandas series to be used for underlying Ensmeble data.

--- a/tests/tape_tests/test_ensemble_frame.py
+++ b/tests/tape_tests/test_ensemble_frame.py
@@ -151,7 +151,9 @@ def test_convert_flux_to_mag(data_fixture, request, err_col, zp_form, out_col_na
 
     else:
         with pytest.raises(ValueError):
-            ens_frame.convert_flux_to_mag("flux", "zp_mag", err_col, zp_form, "mag")
+            ens_frame = ens_frame.convert_flux_to_mag("flux", "zp_mag", err_col, zp_form, "mag")
 
     # Verify that if we converted to a new frame, it's still an EnsembleFrame.
     assert isinstance(ens_frame, EnsembleFrame)
+    assert ens_frame.label == TEST_LABEL
+    assert ens_frame.ensemble is ens


### PR DESCRIPTION
A small fix for `EnsembleFrame.assign()` to correctly propagate the `label` and `ensemble` fields. This appears in calls to `EnsembleFrame.convert_flux_to_magnitude` but was overlooked in the initial testing. Fixed by adding `tape._Frame.assign` which just calls the parent and propagates metadata like we do in `tape._Frame.copy`