### PR TITLE
Support loading ensemble from pandas and dask dataframes

### DIFF
--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -847,8 +847,7 @@ class Ensemble:
         """
         # Construct Dask DataFrames of the source and object tables
         source = dd.from_pandas(source_frame, npartitions=npartitions)
-        object = None if object_frame is None else dd.from_pandas(
-            object_frame, npartitions=npartitions)
+        object = None if object_frame is None else dd.from_pandas(object_frame, npartitions=npartitions)
         return self.from_dask_dataframe(
             source,
             object_frame=object,
@@ -856,7 +855,7 @@ class Ensemble:
             sync_tables=sync_tables,
             npartitions=npartitions,
             partition_size=partition_size,
-            **kwargs
+            **kwargs,
         )
 
     def from_dask_dataframe(
@@ -1131,15 +1130,12 @@ class Ensemble:
                     columns.append(col)
 
         # Read in the source parquet file(s)
-        source = dd.read_parquet(
-            source_file, index=self._id_col, columns=columns, split_row_groups=True
-        )
+        source = dd.read_parquet(source_file, index=self._id_col, columns=columns, split_row_groups=True)
 
         # Generate a provenance column if not provided
         if self._provenance_col is None:
             source["provenance"] = provenance_label
             self._provenance_col = "provenance"
-
 
         object = None
         if object_file:
@@ -1152,7 +1148,7 @@ class Ensemble:
             sync_tables=sync_tables,
             npartitions=npartitions,
             partition_size=partition_size,
-            **kwargs
+            **kwargs,
         )
 
     def from_dataset(self, dataset, **kwargs):

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -847,7 +847,7 @@ class Ensemble:
         """
         # Construct Dask DataFrames of the source and object tables
         source = dd.from_pandas(source_frame, npartitions=npartitions)
-        object = None if object_frame is None else dd.from_pandas(object_frame, npartitions=npartitions)
+        object = None if object_frame is None else dd.from_pandas(object_frame)
         return self.from_dask_dataframe(
             source,
             object_frame=object,
@@ -901,7 +901,7 @@ class Ensemble:
         # Set the index of the source frame and save the resulting table
         self._source = source_frame.set_index(self._id_col, drop=True)
 
-        if object_frame is None:  # generate object table from source
+        if object_frame is None:  # generate an indexed object table from source
             self._object = self._generate_object_table()
             self._nobs_bands = [col for col in list(self._object.columns) if col != self._nobs_tot_col]
         else:
@@ -917,6 +917,8 @@ class Ensemble:
             if self._nobs_tot_col is None:
                 self._object["nobs_total"] = np.nan
                 self._nobs_tot_col = "nobs_total"
+
+            self._object.set_index(self._id_col)
 
             # Optionally sync the tables, recalculates nobs columns
             if sync_tables:

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -896,7 +896,7 @@ class Ensemble:
         ensemble: `tape.ensemble.Ensemble`
             The ensemble object with the Dask dataframe data loaded.
         """
-        self.update_column_mapping(column_mapper, override=False, **kwargs)
+        self._load_column_mapper(column_mapper, **kwargs)
 
         # Set the index of the source frame and save the resulting table
         self._source = source_frame.set_index(self._id_col, drop=True)
@@ -991,7 +991,7 @@ class Ensemble:
         )
         return result
 
-    def update_column_mapping(self, column_mapper=None, override=True, **kwargs):
+    def update_column_mapping(self, column_mapper=None, **kwargs):
         """Update the mapping of column names.
 
         Parameters
@@ -999,8 +999,6 @@ class Ensemble:
         column_mapper: `tape.utils.ColumnMapper`, optional
             An entirely new mapping of column names. If `None` then modifies the
             current mapping using kwargs.
-        override: `bool`, optional
-            Whether to override an existing mapping, by default is `True`.
         kwargs:
             Individual column to name settings.
 
@@ -1008,14 +1006,12 @@ class Ensemble:
         -------
         self: `Ensemble`
         """
-        # Check if a critical column has been set to see if there is a mapping to override.
-        if self._id_col is None or override:
-            if column_mapper is not None:
-                self._load_column_mapper(column_mapper, **kwargs)
-            else:
-                column_mapper = self.make_column_map()
-                column_mapper.assign(**kwargs)
-                self._load_column_mapper(column_mapper, **kwargs)
+        if column_mapper is not None:
+            self._load_column_mapper(column_mapper, **kwargs)
+        else:
+            column_mapper = self.make_column_map()
+            column_mapper.assign(**kwargs)
+            self._load_column_mapper(column_mapper, **kwargs)
         return self
 
     def _load_column_mapper(self, column_mapper, **kwargs):

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -807,6 +807,128 @@ class Ensemble:
         else:
             return batch
 
+    def from_pandas(
+        self,
+        source_frame,
+        object_frame=None,
+        column_mapper=None,
+        sync_tables=True,
+        npartitions=None,
+        partition_size=None,
+        **kwargs,
+    ):
+        """Read in Pandas dataframe(s) into an ensemble object
+
+        Parameters
+        ----------
+        source_frame: 'pandas.Dataframe'
+            A Dask dataframe that contains source information to be read into the ensemble
+        object_frame: 'pandas.Dataframe', optional
+            If not specified, the object frame is generated from the source frame
+        column_mapper: 'ColumnMapper' object
+            If provided, the ColumnMapper is used to populate relevant column
+            information mapped from the input dataset.
+        sync_tables: 'bool', optional
+            In the case where an `object_frame`is provided, determines whether an
+            initial sync is performed between the object and source tables. If
+            not performed, dynamic information like the number of observations
+            may be out of date until a sync is performed internally.
+        npartitions: `int`, optional
+            If specified, attempts to repartition the ensemble to the specified
+            number of partitions
+        partition_size: `int`, optional
+            If specified, attempts to repartition the ensemble to partitions
+            of size `partition_size`.
+
+        Returns
+        ----------
+        ensemble: `tape.ensemble.Ensemble`
+            The ensemble object with the Dask dataframe data loaded.
+        """
+        source = dd.from_pandas(source_frame, npartitions=npartitions, partition_size=partition_size)
+        object = None if object_frame is None else dd.from_pandas(
+            object_frame, npartitions=npartitions, partition_size= partition_size)
+        return self.from_dask_dataframe(
+            source,
+            object_frame=object,
+            column_mapper=column_mapper,
+            sync_tables=sync_tables,
+            npartitions=npartitions,
+            partition_size=partition_size,
+            **kwargs
+        )
+
+    def from_dask_dataframe(
+        self,
+        source_frame,
+        object_frame=None,
+        column_mapper=None,
+        sync_tables=True,
+        npartitions=None,
+        partition_size=None,
+        **kwargs,
+    ):
+        """Read in Dask dataframe(s) into an ensemble object
+
+        Parameters
+        ----------
+        source_frame: 'dask.Dataframe'
+            A Dask dataframe that contains source information to be read into the ensemble
+        object_frame: 'dask.Dataframe', optional
+            If not specified, the object frame is generated from the source frame
+        column_mapper: 'ColumnMapper' object
+            If provided, the ColumnMapper is used to populate relevant column
+            information mapped from the input dataset.
+        sync_tables: 'bool', optional
+            In the case where an `object_frame`is provided, determines whether an
+            initial sync is performed between the object and source tables. If
+            not performed, dynamic information like the number of observations
+            may be out of date until a sync is performed internally.
+        npartitions: `int`, optional
+            If specified, attempts to repartition the ensemble to the specified
+            number of partitions
+        partition_size: `int`, optional
+            If specified, attempts to repartition the ensemble to partitions
+            of size `partition_size`.
+
+        Returns
+        ----------
+        ensemble: `tape.ensemble.Ensemble`
+            The ensemble object with the Dask dataframe data loaded.
+        """
+        self.update_column_mapping(column_mapper, override=False, **kwargs)
+
+        self._source = source_frame
+        if object_frame is None:  # generate object table from source
+            self._object = self._generate_object_table()
+            self._nobs_bands = [col for col in list(self._object.columns) if col != self._nobs_tot_col]
+        else:
+            self._object = object_frame
+            if self._nobs_band_cols is None:
+                # sets empty nobs cols in object
+                unq_filters = np.unique(self._source[self._band_col])
+                self._nobs_band_cols = [f"nobs_{filt}" for filt in unq_filters]
+                for col in self._nobs_band_cols:
+                    self._object[col] = np.nan
+
+            # Handle nobs_total column
+            if self._nobs_tot_col is None:
+                self._object["nobs_total"] = np.nan
+                self._nobs_tot_col = "nobs_total"
+
+            # Optionally sync the tables, recalculates nobs columns
+            if sync_tables:
+                self._source_dirty = True
+                self._object_dirty = True
+                self._sync_tables()
+
+        if npartitions and npartitions > 1:
+            self._source = self._source.repartition(npartitions=npartitions)
+        elif partition_size:
+            self._source = self._source.repartition(partition_size=partition_size)
+
+        return self
+
     def from_hipscat(self, dir, source_subdir="source", object_subdir="object", column_mapper=None, **kwargs):
         """Read in parquet files from a hipscat-formatted directory structure
         Parameters
@@ -867,7 +989,7 @@ class Ensemble:
         )
         return result
 
-    def update_column_mapping(self, column_mapper=None, **kwargs):
+    def update_column_mapping(self, column_mapper=None, override=True, **kwargs):
         """Update the mapping of column names.
 
         Parameters
@@ -875,6 +997,8 @@ class Ensemble:
         column_mapper: `tape.utils.ColumnMapper`, optional
             An entirely new mapping of column names. If `None` then modifies the
             current mapping using kwargs.
+        override: `bool`, optional
+            Whether to override an existing mapping, by default is `True`.
         kwargs:
             Individual column to name settings.
 
@@ -882,12 +1006,14 @@ class Ensemble:
         -------
         self: `Ensemble`
         """
-        if column_mapper is not None:
-            self._load_column_mapper(column_mapper, **kwargs)
-        else:
-            column_mapper = self.make_column_map()
-            column_mapper.assign(**kwargs)
-            self._load_column_mapper(column_mapper, **kwargs)
+        # Check if a critical column has been set to see if there is a mapping to override.
+        if self._id_col is None or override:
+            if column_mapper is not None:
+                self._load_column_mapper(column_mapper, **kwargs)
+            else:
+                column_mapper = self.make_column_map()
+                column_mapper.assign(**kwargs)
+                self._load_column_mapper(column_mapper, **kwargs)
         return self
 
     def _load_column_mapper(self, column_mapper, **kwargs):
@@ -1002,49 +1128,29 @@ class Ensemble:
                     columns.append(col)
 
         # Read in the source parquet file(s)
-        self._source = dd.read_parquet(
+        source = dd.read_parquet(
             source_file, index=self._id_col, columns=columns, split_row_groups=True
         )
 
-        if object_file:  # read from parquet files
-            # Read in the object file(s)
-            self._object = dd.read_parquet(object_file, index=self._id_col, split_row_groups=True)
-
-            if self._nobs_band_cols is None:
-                # sets empty nobs cols in object
-                unq_filters = np.unique(self._source[self._band_col])
-                self._nobs_band_cols = [f"nobs_{filt}" for filt in unq_filters]
-                for col in self._nobs_band_cols:
-                    self._object[col] = np.nan
-
-            # Handle nobs_total column
-            if self._nobs_tot_col is None:
-                self._object["nobs_total"] = np.nan
-                self._nobs_tot_col = "nobs_total"
-
-            # Optionally sync the tables, recalculates nobs columns
-            if sync_tables:
-                self._source_dirty = True
-                self._object_dirty = True
-                self._sync_tables()
-
-        else:  # generate object table from source
-            self._object = self._generate_object_table()
-            self._nobs_bands = [col for col in list(self._object.columns) if col != self._nobs_tot_col]
-
         # Generate a provenance column if not provided
         if self._provenance_col is None:
-            self._source["provenance"] = self._source.apply(
-                lambda x: provenance_label, axis=1, meta=pd.Series(name="provenance", dtype=str)
-            )
+            source["provenance"] = provenance_label
             self._provenance_col = "provenance"
 
-        if npartitions and npartitions > 1:
-            self._source = self._source.repartition(npartitions=npartitions)
-        elif partition_size:
-            self._source = self._source.repartition(partition_size=partition_size)
 
-        return self
+        object = None
+        if object_file:
+            # Read in the object file(s)
+            object = dd.read_parquet(object_file, index=self._id_col, split_row_groups=True)
+        return self.from_dask_dataframe(
+            source_frame=source,
+            object_frame=object,
+            column_mapper=column_mapper,
+            sync_tables=sync_tables,
+            npartitions=npartitions,
+            partition_size=partition_size,
+            **kwargs
+        )
 
     def from_dataset(self, dataset, **kwargs):
         """Load the ensemble from a TAPE dataset.
@@ -1119,20 +1225,21 @@ class Ensemble:
         ensemble: `tape.ensemble.Ensemble`
             The ensemble object with dictionary data loaded
         """
-        # load column mappings
-        self._load_column_mapper(column_mapper, **kwargs)
 
-        # Load in the source data.
-        self._source = dd.DataFrame.from_dict(source_dict, npartitions=npartitions)
-        self._source = self._source.set_index(self._id_col, drop=True)
+        # Load the source data into a dataframe.
+        source_frame = dd.DataFrame.from_dict(source_dict, npartitions=npartitions)
+        source_frame = source_frame.set_index(self._id_col, drop=True)
 
-        # Generate the object table from the source.
-        self._object = self._generate_object_table()
 
-        # Now synced and clean
-        self._source_dirty = False
-        self._object_dirty = False
-        return self
+        return self.from_dask_dataframe(
+            source_frame,
+            object_frame=None,
+            column_mapper=column_mapper,
+            provenance_label="source_dict",
+            sync_tables=True,
+            npartitions=npartitions,
+            **kwargs,
+        )
 
     def convert_flux_to_mag(self, flux_col, zero_point, err_col=None, zp_form="mag", out_col_name=None):
         """Converts a flux column into a magnitude column.

--- a/tests/tape_tests/conftest.py
+++ b/tests/tape_tests/conftest.py
@@ -1,4 +1,5 @@
 """Test fixtures for Ensemble manipulations"""
+import numpy as np
 import pandas as pd
 import dask.dataframe as dd
 
@@ -130,15 +131,15 @@ def dask_dataframe_ensemble(dask_client):
     ens = Ensemble(client=dask_client)
 
     num_points = 1000
-    all_bands = ["r", "g", "b", "i"]
+    all_bands = np.array(["r", "g", "b", "i"])
     rows = {
-        "id": [8000 + (i % 5) for i in range(num_points)],
-        "time": [float(i) for i in range(num_points)],
-        "flux": [float(i % 4) for i in range(num_points)],
-        "band": [all_bands[i % 4] for i in range(num_points)],
-        "err": [0.1*(i % 10) for i in range(num_points)],
-        "count": [i for i in range(num_points)],
-        "something_else": [None for _ in range(num_points)],
+        "id": 8000 + (np.arange(num_points) % 5),
+        "time": np.arange(num_points),
+        "flux": np.arange(num_points) % len(all_bands),
+        "band": np.repeat(all_bands, num_points / len(all_bands)),
+        "err": 0.1 * (np.arange(num_points) % 10),
+        "count": np.arange(num_points),
+        "something_else": np.full(num_points, None),
     }
     cmap = ColumnMapper(id_col="id", time_col="time", flux_col="flux", err_col="err", band_col="band")
 
@@ -157,15 +158,15 @@ def pandas_ensemble(dask_client):
     ens = Ensemble(client=dask_client)
 
     num_points = 1000
-    all_bands = ["r", "g", "b", "i"]
+    all_bands = np.array(["r", "g", "b", "i"])
     rows = {
-        "id": [8000 + (i % 5) for i in range(num_points)],
-        "time": [float(i) for i in range(num_points)],
-        "flux": [float(i % 4) for i in range(num_points)],
-        "band": [all_bands[i % 4] for i in range(num_points)],
-        "err": [0.1*(i % 10) for i in range(num_points)],
-        "count": [i for i in range(num_points)],
-        "something_else": [None for _ in range(num_points)],
+        "id": 8000 + (np.arange(num_points) % 5),
+        "time": np.arange(num_points),
+        "flux": np.arange(num_points) % len(all_bands),
+        "band": np.repeat(all_bands, num_points / len(all_bands)),
+        "err": 0.1 * (np.arange(num_points) % 10),
+        "count": np.arange(num_points),
+        "something_else": np.full(num_points, None),
     }
     cmap = ColumnMapper(id_col="id", time_col="time", flux_col="flux", err_col="err", band_col="band")
 

--- a/tests/tape_tests/conftest.py
+++ b/tests/tape_tests/conftest.py
@@ -118,3 +118,38 @@ def parquet_ensemble_from_hipscat(dask_client):
     )
 
     return ens
+
+# pylint: disable=redefined-outer-name
+@pytest.fixture
+def dataframe_ensemble_without_client():
+    """Create an Ensemble from parquet data without a dask client."""
+    ens = Ensemble(client=False)
+    ens.from_dask_dataframe(
+        "tests/tape_tests/data/source/test_source.parquet",
+        "tests/tape_tests/data/object/test_object.parquet",
+        id_col="ps1_objid",
+        time_col="midPointTai",
+        band_col="filterName",
+        flux_col="psFlux",
+        err_col="psFluxErr",
+    )
+
+    return ens
+
+
+# pylint: disable=redefined-outer-name
+@pytest.fixture
+def dataframe_ensemble(dask_client):
+    """Create an Ensemble from parquet data."""
+    ens = Ensemble(client=dask_client)
+    ens.from_dask_dataframe(
+        "tests/tape_tests/data/source/test_source.parquet",
+        "tests/tape_tests/data/object/test_object.parquet",
+        id_col="ps1_objid",
+        time_col="midPointTai",
+        band_col="filterName",
+        flux_col="psFlux",
+        err_col="psFluxErr",
+    )
+
+    return ens

--- a/tests/tape_tests/test_ensemble.py
+++ b/tests/tape_tests/test_ensemble.py
@@ -90,7 +90,7 @@ def test_from_dataframe(data_fixture, request):
     assert len(obj) == 5
 
     # Check that source and object both have the same ids present
-    assert sorted(np.unique(list(source.index))) == sorted(np.array(obj.index))
+    np.testing.assert_array_equal(np.unique(source.index), np.sort(obj.index))
 
     # Check the we loaded the correct columns.
     for col in [

--- a/tests/tape_tests/test_ensemble.py
+++ b/tests/tape_tests/test_ensemble.py
@@ -67,6 +67,42 @@ def test_from_parquet(data_fixture, request):
         # Check to make sure the critical quantity labels are bound to real columns
         assert parquet_ensemble._source[col] is not None
 
+@pytest.mark.parametrize(
+    "data_fixture",
+    [
+        "dask_dataframe_ensemble",
+        "pandas_ensemble",
+    ],
+)
+def test_from_dataframe(data_fixture, request):
+    """
+    Tests constructing an ensemble from pandas and dask dataframes.
+    """
+    ens = request.getfixturevalue(data_fixture)
+
+    # Check to make sure the source and object tables were created
+    assert ens._source is not None
+    assert ens._object is not None
+
+    # Check that the data is not empty.
+    obj, source = ens.compute()
+    assert len(source) == 1000
+    assert len(obj) == 5
+
+    # Check that source and object both have the same ids present
+    assert sorted(np.unique(list(source.index))) == sorted(np.array(obj.index))
+
+    # Check the we loaded the correct columns.
+    for col in [
+        ens._time_col,
+        ens._flux_col,
+        ens._err_col,
+        ens._band_col,
+    ]:
+        # Check to make sure the critical quantity labels are bound to real columns
+        assert ens._source[col] is not None
+
+
 
 def test_available_datasets(dask_client):
     """


### PR DESCRIPTION
Adds the loader functions `Ensemble.from_pandas` and `Ensemble.from_dask_dataframe`. This allows the user to provide TAPE with their own Pandas or Dask dataframes constructed via their own preferred sources and I/O as outlined in issue [#223](https://github.com/lincc-frameworks/tape/issues/223).

`Ensemble.from_source_dict` and `Ensemble.from_parquet` were simplified with some of their functionality moved into `Ensemble.from_dask_dataframe`.