### PR TITLE
Streamline Object->Source Sync

### DIFF
--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -1367,7 +1367,7 @@ class Ensemble:
             # Sync Object to Source; remove any missing objects from source
             obj_idx = list(self._object.index.compute())
             self._source = self._source.map_partitions(lambda x: x[x.index.isin(obj_idx)])
-            self._source = self._source.persist() # persist the source frame
+            self._source = self._source.persist()  # persist the source frame
 
         if self._source_dirty:  # not elif
             # Generate a new object table; updates n_obs, removes missing ids

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -463,7 +463,6 @@ class Ensemble:
         while i < len(input_cols) - 1:
             coalesce_col = coalesce_col.combine_first(coal_ddf[input_cols[i + 1]])
             i += 1
-        print("am I using this code")
         # Assign the new column to the subset df, and reintroduce index
         coal_ddf = coal_ddf.assign(**{output_col: coalesce_col}).set_index(self._id_col)
 
@@ -1368,7 +1367,7 @@ class Ensemble:
             # Sync Object to Source; remove any missing objects from source
             obj_idx = list(self._object.index.compute())
             self._source = self._source.map_partitions(lambda x: x[x.index.isin(obj_idx)])
-            self._source = self._source.persist()
+            self._source = self._source.persist() # persist the source frame
 
         if self._source_dirty:  # not elif
             # Generate a new object table; updates n_obs, removes missing ids

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -1368,12 +1368,6 @@ class Ensemble:
             # Sync Object to Source; remove any missing objects from source
             obj_idx = list(self._object.index.compute())
             self._source = self._source.map_partitions(lambda x: x[x.index.isin(obj_idx)])
-            """
-            if "index" not in self._source.columns: # use index as identifier if available
-                self._source = self._source.query(f"index in {obj_idx}")
-            else: # if a column is labeled index, fallback to the id_col name
-                self._source = self._source.query(f"{self._id_col} in {obj_idx}")
-            """
             self._source = self._source.persist()
 
         if self._source_dirty:  # not elif


### PR DESCRIPTION
In _sync_tables, the object to source sync involves a full merge between object and source, and then a drop of all remaining object columns. This PR simplifies this by just applying map_partitions to filter down the source dataframe based matches to the object index. It should be about 2x faster.

Science Driver Impact:
The current implementation was causing issues with the single pixel dataset for the Time-Domain MVP project, where _sync_tables was erroring out (int casting error with the residual NaN columns from the merge) whenever the object table was included. The new implementation seems to handle the single-pixel dataset well.