### PR TITLE
coalesce with map_partitions

### DIFF
--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -453,21 +453,25 @@ class Ensemble:
         else:
             raise ValueError(f"{table} is not one of 'object' or 'source'")
 
-        # Create a subset dataframe with the coalesced columns
-        # Drop index for dask series operations - unfortunate
-        coal_ddf = table_ddf[input_cols].reset_index()
+        def coalesce_partition(df, input_cols, output_col):
+            """Coalescing function for a single partition (pandas dataframe)"""
+            coal_df = df[input_cols]
 
-        # Coalesce each column iteratively
-        i = 0
-        coalesce_col = coal_ddf[input_cols[0]]
-        while i < len(input_cols) - 1:
-            coalesce_col = coalesce_col.combine_first(coal_ddf[input_cols[i + 1]])
-            i += 1
-        # Assign the new column to the subset df, and reintroduce index
-        coal_ddf = coal_ddf.assign(**{output_col: coalesce_col}).set_index(self._id_col)
+            # Coalesce each column iteratively
+            i = 0
+            coalesce_col = coal_df[input_cols[0]]
+            while i < len(input_cols) - 1:
+                coalesce_col = coalesce_col.combine_first(coal_df[input_cols[i + 1]])
+                i += 1
+            # Assign the new column to the subset df
+            coal_df = coal_df.assign(**{output_col: coalesce_col})
 
-        # assign the result to the desired column name
-        table_ddf = table_ddf.assign(**{output_col: coal_ddf[output_col]})
+            # assign the result to the desired column name
+            out_df = df.assign(**{output_col: coal_df[output_col]})
+
+            return out_df
+
+        table_ddf = table_ddf.map_partitions(lambda x: coalesce_partition(x, input_cols, output_col))
 
         # Drop the input columns if wanted
         if drop_inputs:

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -456,18 +456,22 @@ class Ensemble:
         def coalesce_partition(df, input_cols, output_col):
             """Coalescing function for a single partition (pandas dataframe)"""
 
+            # Create a subset dataframe per input column
+            # Rename column to output to allow combination
             input_dfs = []
             for col in input_cols:
                 col_df = df[[col]]
 
                 input_dfs.append(col_df.rename(columns={col: output_col}))
 
+            # Combine each dataframe
             i = 0
             coal_df = input_dfs[0]
             while i < len(input_dfs) - 1:
                 coal_df = coal_df.combine_first(input_dfs[i + 1])
                 i += 1
 
+            # Assign the output column to the partition dataframe
             out_df = df.assign(**{output_col: coal_df[output_col]})
 
             return out_df

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -461,15 +461,12 @@ class Ensemble:
             input_dfs = []
             for col in input_cols:
                 col_df = df[[col]]
-
                 input_dfs.append(col_df.rename(columns={col: output_col}))
 
             # Combine each dataframe
-            i = 0
-            coal_df = input_dfs[0]
-            while i < len(input_dfs) - 1:
-                coal_df = coal_df.combine_first(input_dfs[i + 1])
-                i += 1
+            coal_df = input_dfs.pop()
+            while input_dfs:
+                coal_df = coal_df.combine_first(input_dfs.pop())
 
             # Assign the output column to the partition dataframe
             out_df = df.assign(**{output_col: coal_df[output_col]})

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -455,18 +455,19 @@ class Ensemble:
 
         def coalesce_partition(df, input_cols, output_col):
             """Coalescing function for a single partition (pandas dataframe)"""
-            coal_df = df[input_cols]
 
-            # Coalesce each column iteratively
+            input_dfs = []
+            for col in input_cols:
+                col_df = df[[col]]
+
+                input_dfs.append(col_df.rename(columns={col: output_col}))
+
             i = 0
-            coalesce_col = coal_df[input_cols[0]]
-            while i < len(input_cols) - 1:
-                coalesce_col = coalesce_col.combine_first(coal_df[input_cols[i + 1]])
+            coal_df = input_dfs[0]
+            while i < len(input_dfs) - 1:
+                coal_df = coal_df.combine_first(input_dfs[i + 1])
                 i += 1
-            # Assign the new column to the subset df
-            coal_df = coal_df.assign(**{output_col: coalesce_col})
 
-            # assign the result to the desired column name
             out_df = df.assign(**{output_col: coal_df[output_col]})
 
             return out_df


### PR DESCRIPTION
A few weeks ago, the smoke tests failed on the current coalesce function. The initial fix I applied involved resetting the index, which is generally an expensive operation in Dask. This should be a better way to handle things, where we just apply map_partitions to coalesce on a partition-by-partition basis.

Science Driver Impact:
The initial fix to the smoke tests made the coalescing function have issues with the TAPE single pixel dataset for the time-domain MVP, particularly it complained about needing to know the divisions when resetting the index. This new implementation works successfully with the TAPE single-pixel dataset.