### PR TITLE
Set object table index for from_dask_dataframe

### DIFF
--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -852,7 +852,7 @@ class Ensemble:
         """
         # Construct Dask DataFrames of the source and object tables
         source = dd.from_pandas(source_frame, npartitions=npartitions)
-        object = None if object_frame is None else dd.from_pandas(object_frame)
+        object = None if object_frame is None else dd.from_pandas(object_frame, npartitions=npartitions)
         return self.from_dask_dataframe(
             source,
             object_frame=object,
@@ -923,7 +923,7 @@ class Ensemble:
                 self._object["nobs_total"] = np.nan
                 self._nobs_tot_col = "nobs_total"
 
-            self._object.set_index(self._id_col)
+            self._object = self._object.set_index(self._id_col)
 
             # Optionally sync the tables, recalculates nobs columns
             if sync_tables:

--- a/tests/tape_tests/test_ensemble.py
+++ b/tests/tape_tests/test_ensemble.py
@@ -71,7 +71,9 @@ def test_from_parquet(data_fixture, request):
     "data_fixture",
     [
         "dask_dataframe_ensemble",
+        "dask_dataframe_with_object_ensemble",
         "pandas_ensemble",
+        "pandas_with_object_ensemble"
     ],
 )
 def test_from_dataframe(data_fixture, request):
@@ -102,6 +104,9 @@ def test_from_dataframe(data_fixture, request):
         # Check to make sure the critical quantity labels are bound to real columns
         assert ens._source[col] is not None
 
+    # Check that we can compute an analysis function on the ensemble.
+    amplitude = ens.batch(calc_stetson_J)
+    assert len(amplitude) == 5
 
 
 def test_available_datasets(dask_client):


### PR DESCRIPTION
In the loader method `from_dask_dataframe`, we were mistakenly not updating the object table's index in the case where the object table is supplied as an argument rather than generated from the source table.

Unit tests are updated based on the identifying issue [#230](https://github.com/lincc-frameworks/tape/issues/230) validating the case where the object table isn't generated and that analysis functions can be called on the generated  ensemble.