### PR TITLE
Fix EnsembleFrame.set_index

### DIFF
--- a/tests/tape_tests/test_ensemble_frame.py
+++ b/tests/tape_tests/test_ensemble_frame.py
@@ -108,6 +108,15 @@ def test_ensemble_frame_propagation(data_fixture, request):
     assert isinstance(ens_frame.compute(), TapeFrame)
     assert len(ens_frame) == len(ens_frame.compute())
 
+    # Set an index and then group by that index.
+    ens_frame = ens_frame.set_index("id", drop=True)
+    assert ens_frame.label == TEST_LABEL
+    assert ens_frame.ensemble == ens    
+    group_result = ens_frame.groupby(["id"]).count()
+    assert len(group_result) > 0
+    assert isinstance(group_result, EnsembleFrame)
+    assert isinstance(group_result._meta, TapeFrame)
+
 @pytest.mark.parametrize(
     "data_fixture",
     [
@@ -190,7 +199,7 @@ def test_object_and_source_frame_propagation(data_fixture, request):
 
     # Perform a series of operations on the SourceFrame and then verify the result is still a
     # proper SourceFrame with appropriate metadata propagated.
-    mean_ps_flux = source_frame["psFlux"].mean().compute()
+    source_frame["psFlux"].mean().compute()
     result_source_frame = source_frame.copy()[["psFlux", "psFluxErr"]]
     assert isinstance(result_source_frame, SourceFrame)
     assert isinstance(result_source_frame._meta, TapeSourceFrame)
@@ -198,6 +207,15 @@ def test_object_and_source_frame_propagation(data_fixture, request):
     assert result_source_frame.label == SOURCE_LABEL
     assert result_source_frame.ensemble is not None
     assert result_source_frame.ensemble is ens
+
+    # Set an index and then group by that index.
+    result_source_frame = result_source_frame.set_index("psFlux", drop=True)
+    assert result_source_frame.label == SOURCE_LABEL
+    assert result_source_frame.ensemble == ens    
+    group_result = result_source_frame.groupby(["psFlux"]).count()
+    assert len(group_result) > 0
+    assert isinstance(group_result, SourceFrame)
+    assert isinstance(group_result._meta, TapeSourceFrame)
 
     # Create an ObjectFrame from a parquet file
     object_frame = ObjectFrame.from_parquet(
@@ -217,3 +235,12 @@ def test_object_and_source_frame_propagation(data_fixture, request):
     assert isinstance(result_object_frame._meta, TapeObjectFrame)
     assert result_object_frame.label == OBJECT_LABEL
     assert result_object_frame.ensemble is ens
+
+    # Set an index and then group by that index.
+    result_object_frame = result_object_frame.set_index("nobs_g", drop=True)
+    assert result_object_frame.label == OBJECT_LABEL
+    assert result_object_frame.ensemble == ens    
+    group_result = result_object_frame.groupby(["nobs_g"]).count()
+    assert len(group_result) > 0
+    assert isinstance(group_result, ObjectFrame)
+    assert isinstance(group_result._meta, TapeObjectFrame)


### PR DESCRIPTION
Fixes issue where `EnsembleFrame.set_index` does not correctly set a named index.

As an example, `EnsembleFrame.set_index("id")` would fail to produce an `EnsembleFrame` with an index named "id". This would not immediately fail, but performing `groupby["id"]` on the resulting frame would result in a key error since we dropped the column and our index is unnamed. Such a test case has now been added in this PR.

In the previous behavior, the calls to `set_index` eventually produce a call to `dask.dataframe.core.map_partitions` and the incorrect index is constructed in [`_get_meta_map_partition`](https://github.com/dask/dask/blob/216c7c9393d8df1014a911eceb797502999e8a51/dask/dataframe/core.py#L7066). Here the meta is overridden with an incorrect index in the call to

```
meta_index = getattr(make_meta(dfs[0]), "index", None) if dfs else None

...

meta = make_meta(meta, index=meta_index, parent_meta=parent_meta)
```

where the `meta_index` is the unnamed index that was causing the error described above. After some investigation, I discovered that even in the case of a normal dask.DataFrame, `meta_index` is also an unnamed index, but the call to `make_meta` was not causing it to override the existing index. 

A fix is provided in this PR by simply having our calls to `make_meta_*` not override the existing indices.  