### PR TITLE
Update requirements.txt to unpin sphinx

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
-sphinx==6.1.3
-sphinx_rtd_theme==1.2.0
-sphinx-autoapi==2.0.1
+sphinx
+sphinx_rtd_theme
+sphinx-autoapi
 nbsphinx
 ipython
 jupytext

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,9 @@ dev = [
     "pytest",
     "pytest-cov", # Used to report total code coverage
     "pre-commit", # Used to run checks before finalizing a git commit
-    "sphinx==6.1.3", # Used to automatically generate documentation
-    "sphinx_rtd_theme==1.2.0", # Used to render documentation
-    "sphinx-autoapi==2.0.1", # Used to automatically generate api documentation
+    "sphinx", # Used to automatically generate documentation
+    "sphinx_rtd_theme", # Used to render documentation
+    "sphinx-autoapi", # Used to automatically generate api documentation
     "black", # Used for static linting of files
     # if you add dependencies here while experimenting in a notebook and you
     # want that notebook to render in your documentation, please add the


### PR DESCRIPTION
Noticed this while working on my dash; unpinning sphinx to address doc build failure (see https://github.com/lincc-frameworks/python-project-template/issues/294)