### PR TITLE
Add update_ensemble() and Use EnsembleFrames

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
-sphinx==6.1.3
-sphinx_rtd_theme==1.2.0
-sphinx-autoapi==2.0.1
+sphinx
+sphinx_rtd_theme
+sphinx-autoapi
 nbsphinx
 ipython
 jupytext

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,9 @@ dev = [
     "pytest",
     "pytest-cov", # Used to report total code coverage
     "pre-commit", # Used to run checks before finalizing a git commit
-    "sphinx==6.1.3", # Used to automatically generate documentation
-    "sphinx_rtd_theme==1.2.0", # Used to render documentation
-    "sphinx-autoapi==2.0.1", # Used to automatically generate api documentation
+    "sphinx", # Used to automatically generate documentation
+    "sphinx_rtd_theme", # Used to render documentation
+    "sphinx-autoapi", # Used to automatically generate api documentation
     "black", # Used for static linting of files
     # if you add dependencies here while experimenting in a notebook and you
     # want that notebook to render in your documentation, please add the

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -133,7 +133,8 @@ class Ensemble:
 
         Raises
         ------
-        ValueError if the `frame.label` is unpopulated, "source", or "object".
+        ValueError if the `frame.label` is unpopulated, or if the frame is not a SourceFrame or ObjectFrame
+        but uses the reserved labels.
         """
         if frame.label is None:
             raise ValueError(

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -12,7 +12,7 @@ from .analysis.base import AnalysisFunction
 from .analysis.feature_extractor import BaseLightCurveFeature, FeatureExtractor
 from .analysis.structure_function import SF_METHODS
 from .analysis.structurefunction2 import calc_sf2
-from .ensemble_frame import ObjectFrame, SourceFrame
+from .ensemble_frame import ObjectFrame, SourceFrame, TapeObjectFrame
 from .timeseries import TimeSeries
 from .utils import ColumnMapper
 
@@ -45,9 +45,6 @@ class Ensemble:
         # TODO(wbeebe@uw.edu) Replace self._source and self._object with these 
         self.source = None # Source Table EnsembleFrame
         self.object = None # Object Table EnsembleFrame
-
-        self._source_dirty = False  # Source Dirty Flag
-        self._object_dirty = False  # Object Dirty Flag
 
         # Default to removing empty objects.
         self.keep_empty_objects = kwargs.get("keep_empty_objects", False)
@@ -142,10 +139,18 @@ class Ensemble:
             raise ValueError(
                 f"Unable to update frame with no populated `EnsembleFrame.label`."
                 )
-        if frame.label == SOURCE_FRAME_LABEL or frame.label == OBJECT_FRAME_LABEL:
-            raise ValueError(
-                f"Unable to update frame with reserved label " f"'{frame.label}'"
+        if isinstance(frame, SourceFrame) or isinstance(frame, ObjectFrame):
+            expected_label = SOURCE_FRAME_LABEL if isinstance(frame, SourceFrame) else OBJECT_FRAME_LABEL
+            if frame.label != expected_label:
+                raise ValueError(f"Unable to update frame with reserved label " f"'{frame.label}'"
                 )
+            if isinstance(frame, SourceFrame):
+                self._source = frame
+                self.source = frame
+            elif isinstance(frame, ObjectFrame):
+                self._object = frame
+                self.object = frame
+
         # Ensure this frame is assigned to this Ensemble.
         frame.ensemble = self
         self.frames[frame.label] = frame
@@ -316,16 +321,16 @@ class Ensemble:
         prev_num = self._source.npartitions
 
         # Append the new rows to the correct divisions.
-        self._source = dd.concat([self._source, df2], axis=0, interleave_partitions=True)
-        self._source_dirty = True
+        self.update_frame(dd.concat([self._source, df2], axis=0, interleave_partitions=True))
+        self._source.set_dirty(True)
 
         # Do the repartitioning if requested. If the divisions were set, reuse them.
         # Otherwise, use the same number of partitions.
         if force_repartition:
             if all(prev_div):
-                self._source = self._source.repartition(divisions=prev_div)
+                self.update_frame(self._source.repartition(divisions=prev_div))
             elif self._source.npartitions != prev_num:
-                self._source = self._source.repartition(npartitions=prev_num)
+                self.update_frame(self._source.repartition(npartitions=prev_num))
 
     def client_info(self):
         """Calls the Dask Client, which returns cluster information
@@ -379,9 +384,6 @@ class Ensemble:
         A single pandas data frame for the specified table or a tuple of (object, source)
         data frames.
         """
-        # TODO(wbeebe@uw.edu): Remove this logic as part of milestone 4's removal of the _source and _object fields
-        if self.object is not None and self.source is not None:
-            return (self.object.compute(**kwargs), self.source.compute(**kwargs))
         if table:
             self._lazy_sync_tables(table)
             if table == "object":
@@ -401,8 +403,8 @@ class Ensemble:
         of the computation.
         """
         self._lazy_sync_tables("all")
-        self._object = self._object.persist(**kwargs)
-        self._source = self._source.persist(**kwargs)
+        self.update_frame(self._object.persist(**kwargs))
+        self.update_frame(self._source.persist(**kwargs))
 
     def columns(self, table="object"):
         """Retrieve columns from dask dataframe"""
@@ -454,11 +456,11 @@ class Ensemble:
             scheme
         """
         if table == "object":
-            self._object = self._object.dropna(**kwargs)
-            self._object_dirty = True  # This operation modifies the object table
+            self.update_frame(self._object.dropna(**kwargs))
+            self._object.set_dirty(True)  # This operation modifies the object table
         elif table == "source":
-            self._source = self._source.dropna(**kwargs)
-            self._source_dirty = True  # This operation modifies the source table
+            self.update_frame(self._source.dropna(**kwargs))
+            self._source.set_dirty(True)  # This operation modifies the source table
         else:
             raise ValueError(f"{table} is not one of 'object' or 'source'")
 
@@ -479,12 +481,12 @@ class Ensemble:
         self._lazy_sync_tables(table)
         if table == "object":
             cols_to_drop = [col for col in self._object.columns if col not in columns]
-            self._object = self._object.drop(cols_to_drop, axis=1)
-            self._object_dirty = True
+            self.update_frame(self._object.drop(cols_to_drop, axis=1))
+            self._object.set_dirty(True)
         elif table == "source":
             cols_to_drop = [col for col in self._source.columns if col not in columns]
-            self._source = self._source.drop(cols_to_drop, axis=1)
-            self._source_dirty = True
+            self.update_frame(self._source.drop(cols_to_drop, axis=1))
+            self._source.set_dirty(True)
         else:
             raise ValueError(f"{table} is not one of 'object' or 'source'")
 
@@ -513,11 +515,11 @@ class Ensemble:
         """
         self._lazy_sync_tables(table)
         if table == "object":
-            self._object = self._object.query(expr)
-            self._object_dirty = True
+            self.update_frame(self._object.query(expr))
+            self._object.set_dirty(True)
         elif table == "source":
-            self._source = self._source.query(expr)
-            self._source_dirty = True
+            self.update_frame(self._source.query(expr))
+            self._source.set_dirty(True)
         return self
 
     def filter_from_series(self, keep_series, table="object"):
@@ -535,11 +537,11 @@ class Ensemble:
         """
         self._lazy_sync_tables(table)
         if table == "object":
-            self._object = self._object[keep_series]
-            self._object_dirty = True
+            self.update_frame(self._object[keep_series])
+            self._object.set_dirty(True)
         elif table == "source":
-            self._source = self._source[keep_series]
-            self._source_dirty = True
+            self.update_frame(self._source[keep_series])
+            self._source.set_dirty(True)
         return self
 
     def assign(self, table="object", **kwargs):
@@ -570,11 +572,11 @@ class Ensemble:
         self._lazy_sync_tables(table)
 
         if table == "object":
-            self._object = self._object.assign(**kwargs)
-            self._object_dirty = True
+            self.update_frame(self._object.assign(**kwargs))
+            self._object.set_dirty(True)
         elif table == "source":
-            self._source = self._source.assign(**kwargs)
-            self._source_dirty = True
+            self.update_frame(self._source.assign(**kwargs))
+            self._source.set_dirty(True)
         else:
             raise ValueError(f"{table} is not one of 'object' or 'source'")
         return self
@@ -657,9 +659,9 @@ class Ensemble:
             table_ddf = table_ddf.drop(columns=input_cols)
 
         if table == "object":
-            self._object = table_ddf
+            self.update_frame(table_ddf)
         elif table == "source":
-            self._source = table_ddf
+            self.update_frame(table_ddf)
 
         return self
 
@@ -687,9 +689,9 @@ class Ensemble:
 
         # Mask on object table
         mask = self._object[col_name] >= threshold
-        self._object = self._object[mask]
+        self.update_frame(self._object[mask])
 
-        self._object_dirty = True  # Object Table is now dirty
+        self._object.set_dirty(True)  # Object Table is now dirty
 
         return self
 
@@ -828,13 +830,13 @@ class Ensemble:
                 aggr_funs[key] = custom_aggr[key]
 
         # Group the columns by id, band, and time bucket and aggregate.
-        self._source = self._source.groupby([self._id_col, self._band_col, tmp_time_col]).aggregate(aggr_funs)
+        self.update_frame(self._source.groupby([self._id_col, self._band_col, tmp_time_col]).aggregate(aggr_funs))
 
         # Fix the indices and remove the temporary column.
-        self._source = self._source.reset_index().set_index(self._id_col).drop(tmp_time_col, axis=1)
+        self.update_frame(self._source.reset_index().set_index(self._id_col).drop(tmp_time_col, axis=1))
 
         # Mark the source table as dirty.
-        self._source_dirty = True
+        self._source.set_dirty(True)
         return self
 
     def batch(self, func, *args, meta=None, use_map=True, compute=True, on=None, **kwargs):
@@ -1160,14 +1162,13 @@ class Ensemble:
                     columns.append(col)
 
         # Read in the source parquet file(s)
-        self._source = dd.read_parquet(
-            source_file, index=self._id_col, columns=columns, split_row_groups=True
-        )
+        self.update_frame(SourceFrame.from_parquet(
+            source_file, index=self._id_col, columns=columns, ensemble=self,
+        ))
 
         if object_file:  # read from parquet files
             # Read in the object file(s)
-            self._object = dd.read_parquet(object_file, index=self._id_col, split_row_groups=True)
-
+            self.update_frame(ObjectFrame.from_parquet(object_file, index=self._id_col, ensemble=self))
             if self._nobs_band_cols is None:
                 # sets empty nobs cols in object
                 unq_filters = np.unique(self._source[self._band_col])
@@ -1182,12 +1183,12 @@ class Ensemble:
 
             # Optionally sync the tables, recalculates nobs columns
             if sync_tables:
-                self._source_dirty = True
-                self._object_dirty = True
+                self._source.set_dirty(True)
+                self._object.set_dirty(True)
                 self._sync_tables()
 
         else:  # generate object table from source
-            self._object = self._generate_object_table()
+            self.update_frame(self._generate_object_table())
             self._nobs_bands = [col for col in list(self._object.columns) if col != self._nobs_tot_col]
 
         # Generate a provenance column if not provided
@@ -1198,9 +1199,9 @@ class Ensemble:
             self._provenance_col = "provenance"
 
         if npartitions and npartitions > 1:
-            self._source = self._source.repartition(npartitions=npartitions)
+            self.update_frame(self._source.repartition(npartitions=npartitions))
         elif partition_size:
-            self._source = self._source.repartition(partition_size=partition_size)
+            self.update_frame(self._source.repartition(partition_size=partition_size))
 
         return self
     
@@ -1271,11 +1272,11 @@ class Ensemble:
                     columns.append(col)
 
         # Read in the source parquet file(s)
-        self.source = SourceFrame.from_parquet(source_file, index=self._id_col, columns=columns, 
-                                               ensemble=self)
+        self.update_frame(SourceFrame.from_parquet(source_file, index=self._id_col, columns=columns, 
+                                               ensemble=self))
 
         # Read in the object file(s)
-        self.object = ObjectFrame.from_parquet(object_file, index=self._id_col, ensemble=self)
+        self.update_frame(ObjectFrame.from_parquet(object_file, index=self._id_col, ensemble=self))
 
         if self._nobs_band_cols is None:
             # sets empty nobs cols in object
@@ -1297,13 +1298,10 @@ class Ensemble:
             self._provenance_col = "provenance"
 
         if npartitions and npartitions > 1:
-            self.source = self.source.repartition(npartitions=npartitions)
+            self.update_frame(self.source.repartition(npartitions=npartitions))
         elif partition_size:
-            self.source = self.source.repartition(partition_size=partition_size)
+            self.update_frame(self.source.repartition(partition_size=partition_size))
 
-        # Add the source and object tables to the frames tracked by the Ensemble
-        self.frames[self.source.label] = self.source
-        self.frames[self.object.label] = self.object
         return self
 
     def from_dataset(self, dataset, **kwargs):
@@ -1383,15 +1381,16 @@ class Ensemble:
         self._load_column_mapper(column_mapper, **kwargs)
 
         # Load in the source data.
-        self._source = dd.DataFrame.from_dict(source_dict, npartitions=npartitions)
-        self._source = self._source.set_index(self._id_col, drop=True)
+        self.update_frame(SourceFrame.from_dict(source_dict, npartitions=npartitions))
+        self.update_frame(self._source.set_index(self._id_col, drop=True))
 
         # Generate the object table from the source.
-        self._object = self._generate_object_table()
+        # TODO this is not the object Table oh no....
+        self.update_frame(self._generate_object_table())
 
         # Now synced and clean
-        self._source_dirty = False
-        self._object_dirty = False
+        self._source.set_dirty(False)
+        self._object.set_dirty(False)
         return self
  
     def _generate_object_table(self):
@@ -1403,6 +1402,10 @@ class Ensemble:
             .categorize(columns=[self._band_col])
             .pivot_table(values=self._time_col, index=self._id_col, columns=self._band_col, aggfunc="sum")
         )
+
+        # Convert the resulting dataframe into an ObjectFrame
+        # TODO(wbeebe@uw.edu): Inveestigate if we can correctly infer that `res` is an ObjectFrame instead
+        res = ObjectFrame.from_dask_dataframe(res, ensemble=self)
 
         # If the ensemble's keep_empty_objects attribute is True and there are previous
         # objects, then copy them into the res table with counts of zero.
@@ -1451,11 +1454,11 @@ class Ensemble:
             The table being modified. Should be one of "object",
             "source", or "all"
         """
-        if table == "object" and self._source_dirty:  # object table should be updated
+        if table == "object" and self._source.is_dirty():  # object table should be updated
             self._sync_tables()
-        elif table == "source" and self._object_dirty:  # source table should be updated
+        elif table == "source" and self._object.is_dirty():  # source table should be updated
             self._sync_tables()
-        elif table == "all" and (self._source_dirty or self._object_dirty):
+        elif table == "all" and (self._source.is_dirty() or self._object.is_dirty()):
             self._sync_tables()
         return self
 
@@ -1467,29 +1470,29 @@ class Ensemble:
         keep_empty_objects attribute is set to True.
         """
 
-        if self._object_dirty:
+        if self._object.is_dirty():
             # Sync Object to Source; remove any missing objects from source
             s_cols = self._source.columns
-            self._source = self._source.merge(
+            self.update_frame(self._source.merge(
                 self._object, how="right", on=[self._id_col], suffixes=(None, "_obj")
-            )
+            ))
             cols_to_drop = [col for col in self._source.columns if col not in s_cols]
-            self._source = self._source.drop(cols_to_drop, axis=1)
-            self._source = self._source.persist()  # persist source
+            self.update_frame(self._source.drop(cols_to_drop, axis=1))
+            self.update_frame(self._source.persist())  # persist source
 
-        if self._source_dirty:  # not elif
+        if self._source._is_dirty:  # not elif
             # Generate a new object table; updates n_obs, removes missing ids
             new_obj = self._generate_object_table()
 
             # Join old obj to new obj; pulls in other existing obj columns
-            self._object = new_obj.join(self._object, on=self._id_col, how="left", lsuffix="", rsuffix="_old")
+            self.update_frame(new_obj.join(self._object, on=self._id_col, how="left", lsuffix="", rsuffix="_old"))
             old_cols = [col for col in list(self._object.columns) if "_old" in col]
-            self._object = self._object.drop(old_cols, axis=1)
-            self._object = self._object.persist()  # persist object
+            self.update_frame(self._object.drop(old_cols, axis=1))
+            self.update_frame(self._object.persist())  # persist object
 
         # Now synced and clean
-        self._source_dirty = False
-        self._object_dirty = False
+        self._source.set_dirty(False)
+        self._object.set_dirty(False)
         return self
 
     def to_timeseries(

--- a/src/tape/ensemble_frame.py
+++ b/src/tape/ensemble_frame.py
@@ -353,6 +353,28 @@ class EnsembleFrame(_Frame, dd.core.DataFrame):
         result.label = label
         result.ensemble = ensemble
         return result
+    
+    @classmethod
+    def from_dask_dataframe(cl, df, ensemble=None, label=None):
+        """ Returns an EnsembleFrame constructed from a Dask dataframe.
+        Parameters
+        ----------
+        df: `dask.dataframe.DataFrame` or `list`
+            a Dask dataframe to convert to an EnsembleFrame
+        ensemble: `tape.ensemble.Ensemble`, optional
+        |   A link to the Ensemble object that owns this frame.
+        label: `str`, optional
+        |   The label used to by the Ensemble to identify the frame.
+        Returns
+        result: `tape.EnsembleFrame`
+            The constructed EnsembleFrame object.
+        """
+        # Create a EnsembleFrame by mapping the partitions to the appropriate meta, TapeFrame
+        # TODO(wbeebe@uw.edu): Determine if there is a better method
+        result = df.map_partitions(TapeFrame) 
+        result.ensemble = ensemble
+        result.label = label
+        return result
 
     def update_ensemble(self):
         """ Updates the Ensemble linked by the `EnsembelFrame.ensemble` property to track this frame.
@@ -555,6 +577,26 @@ class SourceFrame(EnsembleFrame):
         result.label = SOURCE_FRAME_LABEL
 
         return result
+
+    @classmethod
+    def from_dask_dataframe(cl, df, ensemble=None):
+        """ Returns a SourceFrame constructed from a Dask dataframe..
+        Parameters
+        ----------
+        df: `dask.dataframe.DataFrame` or `list`
+            a Dask dataframe to convert to a SourceFrame
+        ensemble: `tape.ensemble.Ensemble`, optional
+        |   A link to the Ensemble object that owns this frame.
+        Returns
+        result: `tape.SourceFrame`
+            The constructed SourceFrame object.
+        """
+        # Create a SourceFrame by mapping the partitions to the appropriate meta, TapeSourceFrame
+        # TODO(wbeebe@uw.edu): Determine if there is a better method
+        result = df.map_partitions(TapeSourceFrame) 
+        result.ensemble = ensemble
+        result.label = SOURCE_FRAME_LABEL
+        return result
     
 class ObjectFrame(EnsembleFrame):
     """ A subclass of EnsembleFrame for Object data. """
@@ -621,8 +663,8 @@ class ObjectFrame(EnsembleFrame):
         # Create an ObjectFrame by mapping the partitions to the appropriate meta, TapeObjectFrame
         # TODO(wbeebe@uw.edu): Determine if there is a better method
         result = df.map_partitions(TapeObjectFrame) 
-        result.set_ensemble = ensemble
-        result.set_label = OBJECT_FRAME_LABEL
+        result.ensemble = ensemble
+        result.label = OBJECT_FRAME_LABEL
         return result
 
 """

--- a/src/tape/ensemble_frame.py
+++ b/src/tape/ensemble_frame.py
@@ -359,7 +359,7 @@ class EnsembleFrame(_Frame, dd.core.DataFrame):
 
         Returns
         result: `tape.Ensemble`
-            The Esnemble object which tracks this frame.
+            The Ensemble object which tracks this frame, `None` if no such Ensemble.
         """
         if self.ensemble is None:
             return None
@@ -618,8 +618,8 @@ class ObjectFrame(EnsembleFrame):
         result: `tape.ObjectFrame`
             The constructed ObjectFrame object.
         """
-        # Create an ObjectFrame by mapping the partitions to an appropriate meta, TapeObjectFrame
-        # TODO(wbeebe@uw.edu): Determine if their is a better method
+        # Create an ObjectFrame by mapping the partitions to the appropriate meta, TapeObjectFrame
+        # TODO(wbeebe@uw.edu): Determine if there is a better method
         result = df.map_partitions(TapeObjectFrame) 
         result.set_ensemble = ensemble
         result.set_label = OBJECT_FRAME_LABEL

--- a/src/tape/ensemble_frame.py
+++ b/src/tape/ensemble_frame.py
@@ -600,10 +600,30 @@ class ObjectFrame(EnsembleFrame):
         result = dd.read_parquet(
             path, index=index, columns=columns, split_row_groups=True, engine=TapeObjectArrowEngine,
         )
-        result.ensemble=ensemble
+        result.ensemble = ensemble
         result.label= OBJECT_FRAME_LABEL
 
-        return result   
+        return result
+
+    @classmethod
+    def from_dask_dataframe(cl, df, ensemble=None):
+        """ Returns an ObjectFrame constructed from a Dask dataframe..
+        Parameters
+        ----------
+        df: `dask.dataframe.DataFrame` or `list`
+            a Dask dataframe to convert to an ObjectFrame
+        ensemble: `tape.ensemble.Ensemble`, optional
+        |   A link to the Ensemble object that owns this frame.
+        Returns
+        result: `tape.ObjectFrame`
+            The constructed ObjectFrame object.
+        """
+        # Create an ObjectFrame by mapping the partitions to an appropriate meta, TapeObjectFrame
+        # TODO(wbeebe@uw.edu): Determine if their is a better method
+        result = df.map_partitions(TapeObjectFrame) 
+        result.set_ensemble = ensemble
+        result.set_label = OBJECT_FRAME_LABEL
+        return result
 
 """
 Dask Dataframes are constructed indirectly using method dispatching and inference on the

--- a/src/tape/ensemble_frame.py
+++ b/src/tape/ensemble_frame.py
@@ -315,6 +315,8 @@ class EnsembleFrame(_Frame, dd.core.DataFrame):
     """
     _partition_type = TapeFrame # Tracks the underlying data type
 
+    _is_dirty = False # True if the underlying data is out of sync with the Ensemble
+
     def __getitem__(self, key):
         result = super().__getitem__(key)
         if isinstance(result, _Frame):
@@ -351,13 +353,25 @@ class EnsembleFrame(_Frame, dd.core.DataFrame):
         result.label = label
         result.ensemble = ensemble
         return result
+
+    def update_ensemble(self):
+        """ Updates the Ensemble linked by the `EnsembelFrame.ensemble` property to track this frame.
+
+        Returns
+        result: `tape.Ensemble`
+            The Esnemble object which tracks this frame.
+        """
+        if self.ensemble is None:
+            return None
+        # Update the Ensemble to track this frame and return the ensemble.
+        return self.ensemble.update_frame(self)
     
     def convert_flux_to_mag(self, 
                             flux_col, 
                             zero_point, 
                             err_col=None, 
                             zp_form="mag", 
-                            out_col_name=None, 
+                            out_col_name=None,
                             ):
         """Converts this EnsembleFrame's flux column into a magnitude column, returning a new
         EnsembleFrame.
@@ -451,6 +465,12 @@ class EnsembleFrame(_Frame, dd.core.DataFrame):
         result.ensemble=ensemble
 
         return result
+    
+    def is_dirty(self):
+        return self._is_dirty
+    
+    def set_dirty(self, is_dirty):
+        self._is_dirty = is_dirty
 
 class TapeSourceFrame(TapeFrame):
     """A barebones extension of a Pandas frame to be used for underlying Ensemble source data

--- a/tests/tape_tests/test_ensemble.py
+++ b/tests/tape_tests/test_ensemble.py
@@ -1028,8 +1028,6 @@ def test_batch(data_fixture, request, use_map, on):
 
     parquet_ensemble = request.getfixturevalue(data_fixture)
 
-    assert "ps1_objid" == parquet_ensemble._id_col
-
     result = (
         parquet_ensemble.prune(10)
         .dropna(table="source")

--- a/tests/tape_tests/test_ensemble.py
+++ b/tests/tape_tests/test_ensemble.py
@@ -663,7 +663,7 @@ def test_dropna(parquet_ensemble):
     # We do this on the instantiated object (pdf) and convert it back into a
     # ObjectFrame.
     object_pdf.loc[valid_object_id, parquet_ensemble._object.columns[0]] = pd.NA
-    parquet_ensemble.udpate_frame(ObjectFrame.from_tapeframe(TapeObjectFrame(object_pdf), label="object", npartitions=1))
+    parquet_ensemble.update_frame(ObjectFrame.from_tapeframe(TapeObjectFrame(object_pdf), label="object", npartitions=1))
 
     # Try dropping NaNs from object and confirm that we did.
     parquet_ensemble.dropna(table="object")
@@ -1027,6 +1027,8 @@ def test_batch(data_fixture, request, use_map, on):
     """
 
     parquet_ensemble = request.getfixturevalue(data_fixture)
+
+    assert "ps1_objid" == parquet_ensemble._id_col
 
     result = (
         parquet_ensemble.prune(10)


### PR DESCRIPTION
Adds support for `EnsembleFrame.update_ensemble()` and uses the `ObjectFrame` and `SourceFrame` objects throughout the ensemble. 

Note that in order for `_generate_object_table()` to work we also needed to add `ObjectFrame.from_dask_dataframe` to create an `ObjectFrame` from the generated dask table. 

We also move the fields for whether an object or source table is "dirty" into fields within the EnsembleFrames themselves.