### PR TITLE
Have update_frame mark frames as dirty

### DIFF
--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -152,6 +152,10 @@ class Ensemble:
                 self._object = frame
                 self.object = frame
 
+        # Set a frame as dirty if it was previously tracked and the number of rows has changed. 
+        if frame.label in self.frames and len(self.frames[frame.label]) != len(frame):
+            frame.set_dirty(True)
+
         # Ensure this frame is assigned to this Ensemble.
         frame.ensemble = self
         self.frames[frame.label] = frame

--- a/tests/tape_tests/test_ensemble.py
+++ b/tests/tape_tests/test_ensemble.py
@@ -83,14 +83,27 @@ def test_update_ensemble(data_fixture, request):
     # Filter the object table and have the ensemble track the updated table.
     updated_obj = ens._object.query("nobs_total > 50")
     assert updated_obj is not ens._object
+    # Update the ensemble and validate that it marks the object table dirty
+    assert ens._object.is_dirty() == False
     updated_obj.update_ensemble()
+    assert ens._object.is_dirty() == True
     assert updated_obj is ens._object
-
+    
     # Filter the source table and have the ensemble track the updated table.
     updated_src = ens._source.query("psFluxErr > 0.1")
     assert updated_src is not ens._source
+    # Update the ensemble and validate that it marks the source table dirty
+    assert ens._source.is_dirty() == False
     updated_src.update_ensemble()
+    assert ens._source.is_dirty() == True
     assert updated_src is ens._source
+
+    # Compute a result to trigger a table sync
+    obj, src = ens.compute()
+    assert len(obj) > 0 
+    assert len(src) > 0
+    assert ens._object.is_dirty() == False
+    assert ens._source.is_dirty() == False
 
     # Create an additional result table for the ensemble to track.
     cnts = ens._source.groupby([ens._id_col, ens._band_col])[ens._time_col].aggregate("count")


### PR DESCRIPTION
If `Ensemble.update_frame` receives a frame which it currently tracks, it should mark the frame as dirty if the number of rows has changed. (Note that there may be further criteria which can be added in the future.)

Note that in addition to calls to this method by the user, `Ensemble.add_frame` and `EnsembleFrame.update_ensemble` are implemented by calling this method.