### PR TITLE
add check functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dynamic=["version"]
 dependencies = [
     'pandas',
     'numpy<=1.23.5',
-    'dask>=2023.5.0',
+    'dask>=2023.6.1',
     'dask[distributed]',
     'pyarrow',
     'pyvo',

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -152,7 +152,7 @@ class Ensemble:
 
         # Create the new row and set the paritioning to match the original dataframe.
         df2 = dd.DataFrame.from_dict(rows, npartitions=1)
-        df2 = df2.set_index(self._id_col, drop=True, sort=False)
+        df2 = df2.set_index(self._id_col, drop=True, sort=True)
 
         # Save the divisions and number of partitions.
         prev_div = self._source.divisions
@@ -169,6 +169,8 @@ class Ensemble:
                 self._source = self._source.repartition(divisions=prev_div)
             elif self._source.npartitions != prev_num:
                 self._source = self._source.repartition(npartitions=prev_num)
+
+        return self
 
     def client_info(self):
         """Calls the Dask Client, which returns cluster information

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -233,7 +233,7 @@ class Ensemble:
         # Use the existing index function to check if it's sorted (increasing)
         return idx.is_monotonic_increasing.compute()
 
-    def check_lightcurve_cohesion(ens):
+    def check_lightcurve_cohesion(self):
         """Checks to see if lightcurves are split across multiple partitions.
 
         With partitioned data, and source information represented by rows, it
@@ -250,7 +250,7 @@ class Ensemble:
         across multiple partitions (False)
 
         """
-        idx = ens._source.index
+        idx = self._source.index
         counts = idx.map_partitions(lambda a: Counter(a.unique())).compute()
 
         unq_counter = counts[0]

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -1363,7 +1363,7 @@ class Ensemble:
             If the index column is already sorted in increasing order.
             Defaults to False
         sort: `bool`, optional
-            If True, sorts the DataFrame by the id column. Otherwise set the 
+            If True, sorts the DataFrame by the id column. Otherwise set the
             index on the individual existing partitions. Defaults to False.
 
         Returns

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -210,7 +210,8 @@ class Ensemble:
         self._source.info(verbose=verbose, memory_usage=memory_usage, **kwargs)
 
     def check_sorted(self, table="object"):
-        """Checks to see if an Ensemble Dataframe is sorted on the index.
+        """Checks to see if an Ensemble Dataframe is sorted (increasing) on
+        the index.
 
         Parameters
         ----------
@@ -228,7 +229,9 @@ class Ensemble:
             idx = self._source.index
         else:
             raise ValueError(f"{table} is not one of 'object' or 'source'")
-        return idx.map_partitions(lambda a: np.all(a[:-1] <= a[1:])).compute().all()
+
+        # Use the existing index function to check if it's sorted (increasing)
+        return idx.is_monotonic_increasing.compute()
 
     def check_lightcurve_cohesion(ens):
         """Checks to see if lightcurves are split across multiple partitions.
@@ -1346,7 +1349,9 @@ class Ensemble:
 
         return {key: datasets_file[key]["description"] for key in datasets_file.keys()}
 
-    def from_source_dict(self, source_dict, column_mapper=None, npartitions=1, sort=False, **kwargs):
+    def from_source_dict(
+        self, source_dict, column_mapper=None, npartitions=1, sorted=False, sort=False, **kwargs
+    ):
         """Load the sources into an ensemble from a dictionary.
 
         Parameters

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -254,8 +254,8 @@ class Ensemble:
         counts = idx.map_partitions(lambda a: Counter(a.unique())).compute()
 
         unq_counter = counts[0]
-        for i in range(len(counts) - 1):
-            unq_counter += counts[i + 1]
+        for i in range(1, len(counts)):
+            unq_counter += counts[i]
             if any(c >= 2 for c in unq_counter.values()):
                 return False
         return True

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -1014,6 +1014,7 @@ class Ensemble:
         sync_tables=True,
         npartitions=None,
         partition_size=None,
+        sorted=False,
         sort=False,
         **kwargs,
     ):
@@ -1039,9 +1040,12 @@ class Ensemble:
         partition_size: `int`, optional
             If specified, attempts to repartition the ensemble to partitions
             of size `partition_size`.
+        sorted: bool, optional
+            If the index column is already sorted in increasing order.
+            Defaults to False
         sort: `bool`, optional
-        If True, sorts the DataFrame by the id column. Otherwise set the index
-        on the individual existing partitions. Defaults to False.
+            If True, sorts the DataFrame by the id column. Otherwise set the
+            index on the individual existing partitions. Defaults to False.
 
         Returns
         ----------
@@ -1051,14 +1055,14 @@ class Ensemble:
         self._load_column_mapper(column_mapper, **kwargs)
 
         # Set the index of the source frame and save the resulting table
-        self._source = source_frame.set_index(self._id_col, drop=True, sort=sort)
+        self._source = source_frame.set_index(self._id_col, drop=True, sorted=sorted, sort=sort)
 
         if object_frame is None:  # generate an indexed object table from source
             self._object = self._generate_object_table()
 
         else:
             self._object = object_frame
-            self._object = self._object.set_index(self._id_col, sort=sort)
+            self._object = self._object.set_index(self._id_col, sorted=sorted, sort=sort)
 
             # Optionally sync the tables, recalculates nobs columns
             if sync_tables:
@@ -1205,6 +1209,7 @@ class Ensemble:
         additional_cols=True,
         npartitions=None,
         partition_size=None,
+        sorted=False,
         sort=False,
         **kwargs,
     ):
@@ -1239,9 +1244,12 @@ class Ensemble:
         partition_size: `int`, optional
             If specified, attempts to repartition the ensemble to partitions
             of size `partition_size`.
+        sorted: bool, optional
+            If the index column is already sorted in increasing order.
+            Defaults to False
         sort: `bool`, optional
-        If True, sorts the DataFrame by the id column. Otherwise set the index
-        on the individual existing partitions. Defaults to False.
+            If True, sorts the DataFrame by the id column. Otherwise set the
+            index on the individual existing partitions. Defaults to False.
 
         Returns
         ----------
@@ -1279,6 +1287,7 @@ class Ensemble:
             sync_tables=sync_tables,
             npartitions=npartitions,
             partition_size=partition_size,
+            sorted=sorted,
             sort=sort,
             **kwargs,
         )
@@ -1350,9 +1359,12 @@ class Ensemble:
         npartitions: `int`, optional
             If specified, attempts to repartition the ensemble to the specified
             number of partitions
+        sorted: bool, optional
+            If the index column is already sorted in increasing order.
+            Defaults to False
         sort: `bool`, optional
-        If True, sorts the DataFrame by the id column. Otherwise set the index
-        on the individual existing partitions. Defaults to False.
+            If True, sorts the DataFrame by the id column. Otherwise set the 
+            index on the individual existing partitions. Defaults to False.
 
         Returns
         ----------
@@ -1369,6 +1381,7 @@ class Ensemble:
             column_mapper=column_mapper,
             sync_tables=True,
             npartitions=npartitions,
+            sorted=sorted,
             sort=sort,
             **kwargs,
         )

--- a/tests/tape_tests/test_ensemble.py
+++ b/tests/tape_tests/test_ensemble.py
@@ -372,8 +372,15 @@ def test_insert_paritioned(dask_client):
         "flux": [0.5 * float(i) for i in range(num_points)],
         "band": [all_bands[i % 4] for i in range(num_points)],
     }
-    cmap = ColumnMapper(id_col="id", time_col="time", flux_col="flux", err_col="err", band_col="band")
-    ens.from_source_dict(rows, column_mapper=cmap, npartitions=4)
+    cmap = ColumnMapper(
+        id_col="id",
+        time_col="time",
+        flux_col="flux",
+        err_col="err",
+        band_col="band",
+        provenance_col="provenance",
+    )
+    ens.from_source_dict(rows, column_mapper=cmap, npartitions=4, sort=True)
 
     # Save the old data for comparison.
     old_data = ens.compute("source")

--- a/tests/tape_tests/test_ensemble.py
+++ b/tests/tape_tests/test_ensemble.py
@@ -435,6 +435,60 @@ def test_core_wrappers(parquet_ensemble):
     parquet_ensemble.compute()
 
 
+@pytest.mark.parametrize("data_sorted", [True, False])
+def test_check_sorted(dask_client, data_sorted):
+    # Create some fake data.
+
+    if data_sorted:
+        rows = {
+            "id": [8001, 8001, 8001, 8001, 8002, 8002, 8002, 8002, 8002],
+            "time": [10.1, 10.2, 10.2, 11.1, 11.2, 11.3, 11.4, 15.0, 15.1],
+            "band": ["g", "g", "b", "g", "b", "g", "g", "g", "g"],
+            "err": [1.0, 2.0, 1.0, 3.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "flux": [1.0, 2.0, 5.0, 3.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+        }
+    else:
+        rows = {
+            "id": [8001, 8002, 8001, 8001, 8002, 8002, 8001, 8002, 8002],
+            "time": [10.1, 10.2, 10.2, 11.1, 11.2, 11.3, 11.4, 15.0, 15.1],
+            "band": ["g", "g", "b", "g", "b", "g", "g", "g", "g"],
+            "err": [1.0, 2.0, 1.0, 3.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "flux": [1.0, 2.0, 5.0, 3.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+        }
+    cmap = ColumnMapper(id_col="id", time_col="time", flux_col="flux", err_col="err", band_col="band")
+    ens = Ensemble(client=dask_client)
+    ens.from_source_dict(rows, column_mapper=cmap, sort=False)
+
+    assert ens.check_sorted("source") == data_sorted
+
+
+@pytest.mark.parametrize("data_cohesion", [True, False])
+def test_check_lightcurve_cohesion(dask_client, data_cohesion):
+    # Create some fake data.
+
+    if data_cohesion:
+        rows = {
+            "id": [8001, 8001, 8001, 8001, 8001, 8002, 8002, 8002, 8002],
+            "time": [10.1, 10.2, 10.2, 11.1, 11.2, 11.3, 11.4, 15.0, 15.1],
+            "band": ["g", "g", "b", "g", "b", "g", "g", "g", "g"],
+            "err": [1.0, 2.0, 1.0, 3.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "flux": [1.0, 2.0, 5.0, 3.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+        }
+    else:
+        rows = {
+            "id": [8001, 8001, 8001, 8001, 8002, 8002, 8002, 8002, 8001],
+            "time": [10.1, 10.2, 10.2, 11.1, 11.2, 11.3, 11.4, 15.0, 15.1],
+            "band": ["g", "g", "b", "g", "b", "g", "g", "g", "g"],
+            "err": [1.0, 2.0, 1.0, 3.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "flux": [1.0, 2.0, 5.0, 3.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+        }
+    cmap = ColumnMapper(id_col="id", time_col="time", flux_col="flux", err_col="err", band_col="band")
+    ens = Ensemble(client=dask_client)
+    ens.from_source_dict(rows, column_mapper=cmap, sort=False, npartitions=2)
+
+    assert ens.check_lightcurve_cohesion() == data_cohesion
+
+
 def test_persist(dask_client):
     # Create some fake data.
     rows = {

--- a/tests/tape_tests/test_ensemble.py
+++ b/tests/tape_tests/test_ensemble.py
@@ -443,7 +443,8 @@ def test_core_wrappers(parquet_ensemble):
 
 
 @pytest.mark.parametrize("data_sorted", [True, False])
-def test_check_sorted(dask_client, data_sorted):
+@pytest.mark.parametrize("npartitions", [1, 2])
+def test_check_sorted(dask_client, data_sorted, npartitions):
     # Create some fake data.
 
     if data_sorted:
@@ -456,7 +457,7 @@ def test_check_sorted(dask_client, data_sorted):
         }
     else:
         rows = {
-            "id": [8001, 8002, 8001, 8001, 8002, 8002, 8001, 8002, 8002],
+            "id": [8002, 8002, 8002, 8002, 8002, 8001, 8001, 8002, 8002],
             "time": [10.1, 10.2, 10.2, 11.1, 11.2, 11.3, 11.4, 15.0, 15.1],
             "band": ["g", "g", "b", "g", "b", "g", "g", "g", "g"],
             "err": [1.0, 2.0, 1.0, 3.0, 2.0, 3.0, 4.0, 5.0, 6.0],
@@ -464,7 +465,7 @@ def test_check_sorted(dask_client, data_sorted):
         }
     cmap = ColumnMapper(id_col="id", time_col="time", flux_col="flux", err_col="err", band_col="band")
     ens = Ensemble(client=dask_client)
-    ens.from_source_dict(rows, column_mapper=cmap, sort=False)
+    ens.from_source_dict(rows, column_mapper=cmap, sort=False, npartitions=npartitions)
 
     assert ens.check_sorted("source") == data_sorted
 


### PR DESCRIPTION
This PR addresses #275, adding two functions (`check_sorted` and `check_lightcurve_cohesion`) that assess whether the ensemble data is sorted and whether the source data is co-located within single partitions (referring to this as "cohesion"). 

There's a bit of a snowball effect to implementing these, so this ends up addressing #242 by adding a `sort` flag to loader calls that defaults to False. This allows the Ensemble to actually be unsorted, making the `check_sorted` function useful. The sort flag was added to Dask in 2023.6.1, so I've also updated the minimum version to this in `pyproject.toml`, this broke something in `ensemble.insert_sources`, where a small tweak is needed to the ColumnMapper and sorting needs to be on for it and potentially any upstream data loading. This may be confusing to users, but I also see this function as mainly for devs and is probably unlikely that users will need it much? 