### PR TITLE
Fix EnsembleFrame.set_dirty and map_partitions metadata propagation

### DIFF
--- a/src/tape/ensemble_frame.py
+++ b/src/tape/ensemble_frame.py
@@ -117,7 +117,7 @@ class _Frame(dd.core._Frame):
         """
         new_frame.label = self.label
         new_frame.ensemble = self.ensemble
-        new_frame.set_dirty(self._is_dirty)
+        new_frame.set_dirty(self.is_dirty())
         return new_frame
 
     def copy(self):

--- a/src/tape/ensemble_frame.py
+++ b/src/tape/ensemble_frame.py
@@ -81,12 +81,11 @@ class TapeObjectArrowEngine(TapeArrowEngine):
 class _Frame(dd.core._Frame):
     """Base class for extensions of Dask Dataframes that track additional Ensemble-related metadata."""
 
-    _is_dirty = False # True if the underlying data is out of sync with the Ensemble
-
     def __init__(self, dsk, name, meta, divisions, label=None, ensemble=None):
         super().__init__(dsk, name, meta, divisions)
         self.label = label # A label used by the Ensemble to identify this frame.
         self.ensemble = ensemble # The Ensemble object containing this frame.
+        self._is_dirty = False # True if the underlying data is out of sync with the Ensemble
 
     def is_dirty(self):
         return self._is_dirty
@@ -115,7 +114,7 @@ class _Frame(dd.core._Frame):
         """
         new_frame.label = self.label
         new_frame.ensemble = self.ensemble
-        new_frame.set_dirty(self.is_dirty)
+        new_frame.set_dirty(self._is_dirty)
         return new_frame
 
     def copy(self):

--- a/tests/tape_tests/test_ensemble_frame.py
+++ b/tests/tape_tests/test_ensemble_frame.py
@@ -229,9 +229,11 @@ def test_object_and_source_frame_propagation(data_fixture, request):
     assert result_source_frame.is_dirty()
 
     # Set an index and then group by that index.
+    result_source_frame.set_dirty(False)
     result_source_frame = result_source_frame.set_index("psFlux", drop=True)
     assert result_source_frame.label == SOURCE_LABEL
     assert result_source_frame.ensemble == ens    
+    assert not result_source_frame.is_dirty()
     group_result = result_source_frame.groupby(["psFlux"]).count()
     assert len(group_result) > 0
     assert isinstance(group_result, SourceFrame)
@@ -250,6 +252,8 @@ def test_object_and_source_frame_propagation(data_fixture, request):
 
     assert not object_frame.is_dirty()
     object_frame.set_dirty(True)
+    # Verify that this didn't alter the source frame
+    assert not result_source_frame.is_dirty()
 
     # Perform a series of operations on the ObjectFrame and then verify the result is still a
     # proper ObjectFrame with appropriate metadata propagated.


### PR DESCRIPTION
Previously `_Frame._propagate_metadata` called `result.set_dirty(self.is_dirty)` rather than `result.set_dirty(self.is_dirty())`.

This meant that when a transformation was performed on a dataframe, the result frame would return the bound *method* `is_dirty` itself rather than the boolean value returned by that method. In python, a boolean expression operating on a method itself interprets the method as `True`, resulting in unexpected cases where a transformed frame would incorrectly evaluate as dirty. This is fixed and some fields are renamed to avoid confusion.

In addition, `map_partitions` is overridden to propagate metadata if the output of the provided function is another` _Frame` object.