### PR TITLE
Ensemble.update_frame no longer infers if a frame is dirty by checking if row count changed

### DIFF
--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -116,7 +116,7 @@ class Ensemble:
         self.update_frame(frame)
         return self
 
-    def update_frame(self, frame, check_dirty=False):
+    def update_frame(self, frame):
         """Updates a frame tracked by the Ensemble or otherwise adds it to the Ensemble.
         The frame is tracked by its `EnsembleFrame.label` field.
 
@@ -149,12 +149,6 @@ class Ensemble:
             elif isinstance(frame, ObjectFrame):
                 self._object = frame
                 self.object = frame
-
-        # TODO(wbeebe@uw.edu): consider removing this feature entirely
-        if check_dirty:
-            # Set a frame as dirty if it was previously tracked and the number of rows has changed. 
-            if frame.label in self.frames and len(self.frames[frame.label]) != len(frame):
-                frame.set_dirty(True)
 
         # Ensure this frame is assigned to this Ensemble.
         frame.ensemble = self
@@ -462,10 +456,8 @@ class Ensemble:
         """
         if table == "object":
             self.update_frame(self._object.dropna(**kwargs))
-            self._object.set_dirty(True)
         elif table == "source":
             self.update_frame(self._source.dropna(**kwargs))
-            self._source.set_dirty(True)
         else:
             raise ValueError(f"{table} is not one of 'object' or 'source'")
 
@@ -487,11 +479,9 @@ class Ensemble:
         if table == "object":
             cols_to_drop = [col for col in self._object.columns if col not in columns]
             self.update_frame(self._object.drop(cols_to_drop, axis=1))
-            self._object.set_dirty(True)
         elif table == "source":
             cols_to_drop = [col for col in self._source.columns if col not in columns]
             self.update_frame(self._source.drop(cols_to_drop, axis=1))
-            self._source.set_dirty(True)
         else:
             raise ValueError(f"{table} is not one of 'object' or 'source'")
 
@@ -521,10 +511,8 @@ class Ensemble:
         self._lazy_sync_tables(table)
         if table == "object":
             self.update_frame(self._object.query(expr))
-            self._object.set_dirty(True)
         elif table == "source":
             self.update_frame(self._source.query(expr))
-            self._source.set_dirty(True)
         return self
 
     def filter_from_series(self, keep_series, table="object"):
@@ -585,7 +573,6 @@ class Ensemble:
         if table == "object":
             pre_cols = self._object.columns
             self.update_frame(self._object.assign(**kwargs))
-            self._object.set_dirty(True)
             post_cols = self._object.columns
 
             if temporary:
@@ -594,7 +581,6 @@ class Ensemble:
         elif table == "source":
             pre_cols = self._source.columns
             self.update_frame(self._source.assign(**kwargs))
-            self._source.set_dirty(True)
             post_cols = self._source.columns
 
             if temporary:

--- a/src/tape/ensemble_frame.py
+++ b/src/tape/ensemble_frame.py
@@ -186,8 +186,9 @@ class _Frame(dd.core._Frame):
             import numexpr
             numexpr.set_num_threads(1)
         """
-        result = super().query(expr, **kwargs)
-        return self._propagate_metadata(result)
+        result = self._propagate_metadata(super().query(expr, **kwargs))
+        result.set_dirty(True)
+        return result
         
     def merge(self, right, **kwargs):
         """Merge the Dataframe with another DataFrame

--- a/src/tape/ensemble_frame.py
+++ b/src/tape/ensemble_frame.py
@@ -147,8 +147,9 @@ class _Frame(dd.core._Frame):
         result: `tape._Frame`
             The modifed frame
         """
-        result = super().assign(**kwargs)
-        return self._propagate_metadata(result)
+        result = self._propagate_metadata(super().assign(**kwargs))
+        result.set_dirty(True)
+        return result
     
     def query(self, expr, **kwargs):
         """Filter dataframe with complex expression
@@ -318,9 +319,41 @@ class _Frame(dd.core._Frame):
             Returns the frame or Nonewith the specified
             index or column labels removed or None if inplace=True.
         """
-        result = super().drop(labels=labels, axis=axis, columns=columns, errors=errors)
-        return self._propagate_metadata(result)
+        result = self._propagate_metadata(super().drop(labels=labels, axis=axis, columns=columns, errors=errors))
+        result.set_dirty(True)
+        return result
     
+    def dropna(self, **kwargs):
+        """
+        Remove missing values.
+
+        Doc string below derived from dask.dataframe.core
+
+        Parameters
+        ----------
+
+        how : {'any', 'all'}, default 'any'
+            Determine if row or column is removed from DataFrame, when we have
+            at least one NA or all NA.
+
+            * 'any' : If any NA values are present, drop that row or column.
+            * 'all' : If all values are NA, drop that row or column.
+
+        thresh : int, optional
+            Require that many non-NA values. Cannot be combined with how.
+        subset : column label or sequence of labels, optional
+            Labels along other axis to consider, e.g. if you are dropping rows
+            these would be a list of columns to include.
+
+        Returns
+        ----------
+        result: `tape._Frame`
+            The modifed frame with NA entries dropped from it or None if ``inplace=True``.
+        """
+        result = self._propagate_metadata(super().dropna(**kwargs))
+        result.set_dirty(True)
+        return result
+
     def persist(self, **kwargs):
         """Persist this dask collection into memory
 

--- a/tests/tape_tests/test_ensemble.py
+++ b/tests/tape_tests/test_ensemble.py
@@ -136,6 +136,7 @@ def test_update_ensemble(data_fixture, request):
     # Filter the object table and have the ensemble track the updated table.
     updated_obj = ens._object.query("nobs_total > 50")
     assert updated_obj is not ens._object
+    assert updated_obj.is_dirty()
     # Update the ensemble and validate that it marks the object table dirty
     assert ens._object.is_dirty() == False
     updated_obj.update_ensemble()


### PR DESCRIPTION
Previously a call to`EnsembleFrame.update_frame(x)` for frame `x` would check if that frame was previously tracked, and if the row count had changed, would mark `x` as a dirty frame.

However, getting the row count through calls to `len` on a Dask dataframe can alter the task graph and cause lazy operations to be evaluated earlier. This was in particular causing significant slowdown in _sync_tables on a test notebook by forcing some lazy operations to be performed earlier. 

Here we move the calls to `set_dirty` to our methods wrapping Dask dataframe operations, including a new wrapper for `dropna`.

This may result in an increase in the number of syncs since even a `dropna` call on a table with no "na" values will now mark the table as dirty. However it should not result in more syncs than what is currently performed in the `main` branch.