### PR TITLE
Check Divisions, Enable Lazy Sync Operations on Divisions-enabled Ensembles, Overhaul Object Table Generation

### DIFF
--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -678,8 +678,6 @@ class Ensemble:
 
         # Mask on object table
         self = self.query(f"{col_name} >= {threshold}", table="object")
-        # mask = self._object[col_name] >= threshold
-        # self._object = self._object[mask]
 
         self._object_dirty = True  # Object Table is now dirty
 

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -618,8 +618,10 @@ class Ensemble:
 
             # repartition the result to align with object
             if self._object.known_divisions:
-                self._object.divisions = tuple([None for i in range(self._object.npartitions + 1)])
-                band_counts = band_counts.repartition(npartitions=self._object.npartitions)
+                # self._object.divisions = tuple([None for i in range(self._object.npartitions + 1)])
+                band_counts.divisions = self._source.divisions
+                band_counts = band_counts.repartition(divisions=self._object.divisions)
+                # band_counts = band_counts.repartition(npartitions=self._object.npartitions)
             else:
                 band_counts = band_counts.repartition(npartitions=self._object.npartitions)
 
@@ -636,9 +638,10 @@ class Ensemble:
             counts = self._source.groupby([self._id_col])[[self._band_col]].aggregate("count")
 
             # repartition the result to align with object
-            if self._object.known_divisions:
-                self._object.divisions = tuple([None for i in range(self._object.npartitions + 1)])
-                counts = counts.repartition(npartitions=self._object.npartitions)
+            if self._object.known_divisions and self._source.known_divisions:
+                # self._object.divisions = tuple([None for i in range(self._object.npartitions + 1)])
+                counts.divisions = self._source.divisions
+                counts = counts.repartition(divisions=self._object.divisions)
             else:
                 counts = counts.repartition(npartitions=self._object.npartitions)
 

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -618,10 +618,8 @@ class Ensemble:
 
             # repartition the result to align with object
             if self._object.known_divisions:
-                # self._object.divisions = tuple([None for i in range(self._object.npartitions + 1)])
                 band_counts.divisions = self._source.divisions
                 band_counts = band_counts.repartition(divisions=self._object.divisions)
-                # band_counts = band_counts.repartition(npartitions=self._object.npartitions)
             else:
                 band_counts = band_counts.repartition(npartitions=self._object.npartitions)
 
@@ -639,7 +637,6 @@ class Ensemble:
 
             # repartition the result to align with object
             if self._object.known_divisions and self._source.known_divisions:
-                # self._object.divisions = tuple([None for i in range(self._object.npartitions + 1)])
                 counts.divisions = self._source.divisions
                 counts = counts.repartition(divisions=self._object.divisions)
             else:
@@ -956,6 +953,11 @@ class Ensemble:
                 ),
                 meta=meta,
             )
+
+        # Inherit divisions if known from source and the resulting index is the id
+        # Groupby on index should always return a subset that adheres to the same divisions criteria
+        if self._source.known_divisions and batch.index.name == self._id_col:
+            batch.divisions = self._source.divisions
 
         if compute:
             return batch.compute()
@@ -1687,8 +1689,12 @@ class Ensemble:
                 self._source.index,
                 argument_container=argument_container,
             )
-            return result
+
         else:
             result = self.batch(calc_sf2, use_map=use_map, argument_container=argument_container)
 
-            return result
+        # Inherit divisions information if known
+        if self._source.known_divisions and self._object.known_divisions:
+            result.divisions = self._source.divisions
+
+        return result

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -611,6 +611,7 @@ class Ensemble:
                 self._source.groupby([self._id_col])[self._band_col]  # group by each object
                 .value_counts()  # count occurence of each band
                 .to_frame()  # convert series to dataframe
+                .rename(columns={self._band_col: "counts"})  # rename column
                 .reset_index()  # break up the multiindex
                 .categorize(columns=[self._band_col])  # retype the band labels as categories
                 .pivot_table(values=self._band_col, index=self._id_col, columns=self._band_col, aggfunc="sum")

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -1647,7 +1647,7 @@ class Ensemble:
         index = pd.MultiIndex.from_tuples(tuples, names=["object_id", "band", "index"])
         return index
 
-    def sf2(self, sf_method="basic", argument_container=None, use_map=True):
+    def sf2(self, sf_method="basic", argument_container=None, use_map=True, compute=True):
         """Wrapper interface for calling structurefunction2 on the ensemble
 
         Parameters
@@ -1691,7 +1691,9 @@ class Ensemble:
             )
 
         else:
-            result = self.batch(calc_sf2, use_map=use_map, argument_container=argument_container)
+            result = self.batch(
+                calc_sf2, use_map=use_map, argument_container=argument_container, compute=compute
+            )
 
         # Inherit divisions information if known
         if self._source.known_divisions and self._object.known_divisions:

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -677,8 +677,9 @@ class Ensemble:
             col_name = "nobs_total"
 
         # Mask on object table
-        mask = self._object[col_name] >= threshold
-        self._object = self._object[mask]
+        self = self.query(f"{col_name} >= {threshold}", table="object")
+        # mask = self._object[col_name] >= threshold
+        # self._object = self._object[mask]
 
         self._object_dirty = True  # Object Table is now dirty
 
@@ -1278,7 +1279,7 @@ class Ensemble:
                 columns.append(self._provenance_col)
 
         # Read in the source parquet file(s)
-        source = dd.read_parquet(source_file, columns=columns, split_row_groups=True)
+        source = dd.read_parquet(source_file, index=False, columns=columns, split_row_groups=True)
 
         # Generate a provenance column if not provided
         if self._provenance_col is None:
@@ -1288,7 +1289,7 @@ class Ensemble:
         object = None
         if object_file:
             # Read in the object file(s)
-            object = dd.read_parquet(object_file, split_row_groups=True)
+            object = dd.read_parquet(object_file, index=False, split_row_groups=True)
         return self.from_dask_dataframe(
             source_frame=source,
             object_frame=object,

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -1474,10 +1474,6 @@ class Ensemble:
 
     def _generate_object_table(self):
         """Generate an empty object table from the source table."""
-        # sor_idx = self._source.index.unique()
-        # obj_df = pd.DataFrame(index=sor_idx)
-        # res = dd.from_pandas(obj_df, npartitions=int(np.ceil(self._source.npartitions / 100)))
-
         res = self._source.map_partitions(lambda x: pd.DataFrame(index=x.index.unique()))
 
         return res

--- a/tests/tape_tests/conftest.py
+++ b/tests/tape_tests/conftest.py
@@ -254,6 +254,25 @@ def parquet_ensemble(dask_client):
 
 # pylint: disable=redefined-outer-name
 @pytest.fixture
+def parquet_ensemble_with_divisions(dask_client):
+    """Create an Ensemble from parquet data."""
+    ens = Ensemble(client=dask_client)
+    ens.from_parquet(
+        "tests/tape_tests/data/source/test_source.parquet",
+        "tests/tape_tests/data/object/test_object.parquet",
+        id_col="ps1_objid",
+        time_col="midPointTai",
+        band_col="filterName",
+        flux_col="psFlux",
+        err_col="psFluxErr",
+        sort=True,
+    )
+
+    return ens
+
+
+# pylint: disable=redefined-outer-name
+@pytest.fixture
 def parquet_ensemble_from_source(dask_client):
     """Create an Ensemble from parquet data, with object file withheld."""
     ens = Ensemble(client=dask_client)

--- a/tests/tape_tests/test_ensemble.py
+++ b/tests/tape_tests/test_ensemble.py
@@ -572,10 +572,19 @@ def test_update_column_map(dask_client):
     assert cmap_2.map["provenance_col"] == "p"
 
 
-def test_sync_tables(parquet_ensemble):
+@pytest.mark.parametrize(
+    "data_fixture",
+    [
+        "parquet_ensemble",
+        "parquet_ensemble_with_divisions",
+    ],
+)
+def test_sync_tables(data_fixture, request):
     """
     Test that _sync_tables works as expected
     """
+
+    parquet_ensemble = request.getfixturevalue(data_fixture)
 
     assert len(parquet_ensemble.compute("object")) == 15
     assert len(parquet_ensemble.compute("source")) == 2000
@@ -598,6 +607,11 @@ def test_sync_tables(parquet_ensemble):
     # dirty flags should be unset after sync
     assert not parquet_ensemble._object_dirty
     assert not parquet_ensemble._source_dirty
+
+    # Make sure that divisions are preserved
+    if data_fixture == "parquet_ensemble_with_divisions":
+        assert parquet_ensemble._source.known_divisions
+        assert parquet_ensemble._object.known_divisions
 
 
 def test_lazy_sync_tables(parquet_ensemble):

--- a/tests/tape_tests/test_ensemble.py
+++ b/tests/tape_tests/test_ensemble.py
@@ -1309,15 +1309,20 @@ def test_sf2(data_fixture, request, method, combine, sthresh, use_map=False):
     arg_container.combine = combine
     arg_container.bin_count_target = sthresh
 
-    res_sf2 = parquet_ensemble.sf2(argument_container=arg_container, use_map=use_map)
+    if not combine:
+        res_sf2 = parquet_ensemble.sf2(argument_container=arg_container, use_map=use_map, compute=False)
+    else:
+        res_sf2 = parquet_ensemble.sf2(argument_container=arg_container, use_map=use_map)
     res_batch = parquet_ensemble.batch(calc_sf2, use_map=use_map, argument_container=arg_container)
 
     if parquet_ensemble._source.known_divisions and parquet_ensemble._object.known_divisions:
-        assert res_sf2.known_divisions
+        if not combine:
+            assert res_sf2.known_divisions
 
     if combine:
         assert not res_sf2.equals(res_batch)  # output should be different
     else:
+        res_sf2 = res_sf2.compute()
         assert res_sf2.equals(res_batch)  # output should be identical
 
 

--- a/tests/tape_tests/test_ensemble.py
+++ b/tests/tape_tests/test_ensemble.py
@@ -707,8 +707,6 @@ def test_temporary_cols(parquet_ensemble):
 def test_dropna(data_fixture, request):
     parquet_ensemble = request.getfixturevalue(data_fixture)
 
-    # print(parquet_ensemble._object.compute(), len(parquet_ensemble._object.index), len(parquet_ensemble._object.index.unique()))
-
     # Try passing in an unrecognized 'table' parameter and verify an exception is thrown
     with pytest.raises(ValueError):
         parquet_ensemble.dropna(table="banana")
@@ -717,11 +715,9 @@ def test_dropna(data_fixture, request):
     #
     source_pdf = parquet_ensemble._source.compute()
     source_length = len(source_pdf.index)
-    # source_length = len(parquet_ensemble._source)
 
     # Try dropping NaNs from source and confirm nothing is dropped (there are no NaNs).
     parquet_ensemble.dropna(table="source")
-    # assert len(parquet_ensemble._source.compute().index) == source_length
     assert len(parquet_ensemble._source) == source_length
 
     # Get a valid ID to use and count its occurrences.
@@ -742,11 +738,7 @@ def test_dropna(data_fixture, request):
         # divisions should be preserved
         assert parquet_ensemble._source.known_divisions
 
-    # Sync the table and check that the number of objects decreased.
-    # parquet_ensemble._sync_tables()
-
     # Now test dropping na from 'object' table
-    #
 
     object_pdf = parquet_ensemble._object.compute()
     object_length = len(object_pdf.index)


### PR DESCRIPTION
This PR does a few things that maybe I should have split up into different PRs, but there's also a decent amount of overlap. In this PR, I added more explicit support for Dask Divisions. In particular, checking if they are set after loading in data and warning the user if they are not. Divisions are also checked during sync operations to enable a new completely lazy sync that doesn't need to load the index fully into memory. In addition, the object table generation off the source table has been made lazy as well, removing the current unscalable implementation that loads the entire index into a pandas dataframe.