### PR TITLE
Support storing batch results for custom meta

### DIFF
--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -1125,9 +1125,7 @@ class Ensemble:
                 # expensive computation.
                 warnings.warn(
                     f"""Warning: Batch successfully computed but failed to track frame under label,
-                      {label}, due to incompatible meta: {meta}""",
-                      label,
-                      meta)
+                      {label}, due to incompatible meta: {meta}""")
 
         if compute:
             return batch.compute()

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -21,6 +21,8 @@ from .utils import ColumnMapper
 SOURCE_FRAME_LABEL = "source"
 OBJECT_FRAME_LABEL = "object"
 
+DEFAULT_FRAME_LABEL = "result" # A base default label for an Ensemble's result frames.
+
 class Ensemble:
     """Ensemble object is a collection of light curve ids"""
 
@@ -42,6 +44,9 @@ class Ensemble:
         self._object = None  # Object Table
 
         self.frames = {} # Frames managed by this Ensemble, keyed by label
+
+        # A unique ID to allocate new result frame labels.
+        self.default_frame_id = 1
 
         # TODO(wbeebe@uw.edu) Replace self._source and self._object with these 
         self.source = None # Source Table EnsembleFrame
@@ -208,7 +213,7 @@ class Ensemble:
                 f"Unable to select frame: no frame with label" f"'{label}'" f" is in the Ensemble."
                 )
         return self.frames[label]
-
+    
     def frame_info(self, labels=None, verbose=True, memory_usage=True, **kwargs):
         """Wrapper for calling dask.dataframe.DataFrame.info() on frames tracked by the Ensemble.
 
@@ -242,6 +247,18 @@ class Ensemble:
                     )
             print(label, "Frame")
             print(self.frames[label].info(verbose=verbose, memory_usage=memory_usage, **kwargs))
+
+    def _generate_frame_label(self):
+        """ Generates a new unique label for a result frame. """
+        result = DEFAULT_FRAME_LABEL + "_" + str(self.default_frame_id)
+        self.default_frame_id += 1 # increment to guarantee uniqueness
+        while result in self.frames:
+            # If the generated label has been taken by a user, increment again.
+            # In most workflows, we expect the number of frames to be O(100) so it's unlikely for
+            # the performance cost of this method to be high.
+            result = DEFAULT_FRAME_LABEL + "_" + str(self.default_frame_id)
+            self.default_frame_id += 1
+        return result
 
     def insert_sources(
         self,
@@ -983,7 +1000,7 @@ class Ensemble:
         self._source.set_dirty(True)
         return self
 
-    def batch(self, func, *args, meta=None, use_map=True, compute=True, on=None, label=None, **kwargs):
+    def batch(self, func, *args, meta=None, use_map=True, compute=True, on=None, label="", **kwargs):
         """Run a function from tape.TimeSeries on the available ids
 
         Parameters
@@ -1023,7 +1040,9 @@ class Ensemble:
             this is populated automatically.
         label: 'str', optional
             If provided the ensemble will use this label to track the result 
-            dataframe. If `None`, the frame will not be tracked. 
+            dataframe. If not provided, a label of the from "result_{x}" where x
+            is a monotonically increasing integer is generated. If `None`,
+            the result frame will not be tracked. 
         **kwargs:
             Additional optional parameters passed for the selected function
 
@@ -1116,17 +1135,11 @@ class Ensemble:
             )
 
         if label is not None:
-            if isinstance(batch, EnsembleFrame) or isinstance(batch, EnsembleSeries):
-                # Track the result frame under the provided label
-                self.add_frame(batch, label)
-            else:
-                # The result of the batch function was not a frame/series we don't support tracking.
-                # However we opt to provide a warning so that the user won't lose a potentially
-                # expensive computation.
-                warnings.warn(
-                    f"""Warning: Batch successfully computed but failed to track frame under label,
-                      {label}, due to incompatible meta: {meta}""")
-
+            if  label == "":
+                label = self._generate_frame_label()
+                print(f"Using generated label, {label}, for a batch result.")
+            # Track the result frame under the provided label
+            self.add_frame(batch, label)
         if compute:
             return batch.compute()
         else:

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -1854,6 +1854,16 @@ class Ensemble:
 
     def _translate_meta(self, meta):
         """Translates Dask-style meta into a TapeFrame or TapeSeries object.
+
+        Parameters
+        ----------
+        meta : `dict`, `tuple`, `list`, `pd.Series`, `pd.DataFrame`, `pd.Index`, `dtype`, `scalar`
+
+        Returns
+        ----------
+        result : `ensemble.TapeFrame` or `ensemble.TapeSeries`
+            The appropriate meta for Dask producing an `Ensemble.EnsembleFrame` or
+            `Ensemble.EnsembleSeries` respectively
         """
         if isinstance(meta, TapeFrame) or isinstance(meta, TapeSeries):
             return meta

--- a/src/tape/ensemble_frame.py
+++ b/src/tape/ensemble_frame.py
@@ -4,7 +4,7 @@ import dask.dataframe as dd
 
 import dask
 from dask.dataframe.dispatch import make_meta_dispatch
-from dask.dataframe.backends import _nonempty_index, meta_nonempty, meta_nonempty_dataframe
+from dask.dataframe.backends import _nonempty_index, meta_nonempty, meta_nonempty_dataframe, _nonempty_series
 
 from dask.dataframe.core import get_parallel_type
 from dask.dataframe.extensions import make_array_nonempty
@@ -978,7 +978,8 @@ def make_meta_frame(x, index=None):
 @meta_nonempty.register(TapeSeries)
 def _nonempty_tapeseries(x, index=None):
     # Construct a new TapeSeries with the same underlying data.
-    return TapeSeries(data, name=x.name, crs=x.crs)
+    data = _nonempty_series(x)
+    return TapeSeries(data)
 
 @meta_nonempty.register(TapeFrame)
 def _nonempty_tapeseries(x, index=None):

--- a/tests/tape_tests/test_ensemble.py
+++ b/tests/tape_tests/test_ensemble.py
@@ -1480,8 +1480,6 @@ def test_batch_with_custom_frame_meta(parquet_ensemble, custom_meta):
     """
     num_frames = len(parquet_ensemble.frames)
 
-    assert isinstance(custom_meta, TapeFrame)
-
     parquet_ensemble.prune(10).batch(
         calc_sf2, parquet_ensemble._flux_col, meta=custom_meta, label="sf2_result")
 


### PR DESCRIPTION
`Ensemble.batch` should track a result dataframe when the `label` parameter is used, and it should correctly translate the meta for the batch operation to be either an `TapeFrame` or `TapeSeries` (which Dask will use to map the batched result to either be an `EnsembleFrame` or `EnsembleSeries` respectively).

Note that `Ensemble.batch` still returns the result frame rather than the `Ensemble` to keep the API backwards compatible, but we can later have it return the `Ensemble` object to allow for easier chaining of commands.

Fixes a bug for creating meta for a non-empty EnsembleSeries.