### PR TITLE
Allow EnsembleFrame.compute to Trigger Object-Source Table Syncing

### DIFF
--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -1670,6 +1670,25 @@ class Ensemble:
 
         return res
 
+    def _lazy_sync_tables_from_frame(self, frame):
+        """Call the sync operation for the frame only if the 
+        table being modified (`frame`) needs to be synced.
+        Does nothing in the case that only the table to be modified
+        is dirty or if it is not the object or source frame for this
+        `Ensemble`.
+
+        Parameters
+        ----------
+        frame: `tape.EnsembleFrame`
+            The frame being modified. Only an `ObjectFrame` or
+            `SourceFrame tracked by this `Ensemble` may trigger
+            a sync.
+        """
+        if frame is self.object or frame is self.source:
+            # See if we should sync the Object or Source tables.
+            self._lazy_sync_tables(frame.label)
+        return self
+
     def _lazy_sync_tables(self, table="object"):
         """Call the sync operation for the table only if the
         the table being modified (`table`) needs to be synced.

--- a/src/tape/ensemble_frame.py
+++ b/src/tape/ensemble_frame.py
@@ -556,6 +556,35 @@ class _Frame(dd.core._Frame):
             # If the output of func is another _Frame, let's propagate any metadata.
             return self._propagate_metadata(result)
         return result
+    
+    def compute(self, **kwargs):
+        """Compute this Dask collection, returning the underlying dataframe or series.
+        If tracked by an `Ensemble`, the `Ensemble` is informed of this operation and
+        is given the opportunity to sync any of its tables prior to this Dask collection
+        being computed.
+
+        Doc string below derived from dask.dataframe.DataFrame.compute
+
+        This turns a lazy Dask collection into its in-memory equivalent. For example 
+        a Dask array turns into a NumPy array and a Dask dataframe turns into a
+        Pandas dataframe. The entire dataset must fit into memory before calling
+        this operation.
+
+        Parameters
+        ----------
+        scheduler: `string`, optional
+            Which scheduler to use like “threads”, “synchronous” or “processes”. 
+            If not provided, the default is to check the global settings first,
+            and then fall back to the collection defaults.
+        optimize_graph: `bool`, optional
+            If True [default], the graph is optimized before computation. 
+            Otherwise the graph is run as is. This can be useful for debugging.
+        **kwargs: `dict`, optional
+            Extra keywords to forward to the scheduler function.
+        """
+        if self.ensemble is not None:
+            self.ensemble._lazy_sync_tables_from_frame(self)
+        return super().compute(**kwargs)
 
 class TapeSeries(pd.Series):
     """A barebones extension of a Pandas series to be used for underlying Ensemble data.

--- a/tests/tape_tests/test_ensemble.py
+++ b/tests/tape_tests/test_ensemble.py
@@ -1253,7 +1253,7 @@ def test_select(dask_client):
 @pytest.mark.parametrize("legacy", [True, False])
 def test_assign(dask_client, legacy):
     """Tests assign for column-manipulation, using Ensemble.assign when `legacy` is `True`,
-    and EnsembleFrame.assign when `legacy` is `False`.
+    and EnsembleFrame.assign when `legacy` is `False`."""
     ens = Ensemble(client=dask_client)
 
     num_points = 1000


### PR DESCRIPTION
When `Ensemble.object.compute()` or `Ensemble.source.compute()` are called we would like to give the `Ensemble` a chance to perform an Object-Source table sync prior to computing the result.

Some previously tested workflows had other functions triggering syncs at the appropriate times (such as `Ensemble.batch`) or were using `Ensemble.compute()`. Now calling `EnsembleFrame.compute` should trigger any potential syncing for the tracking `Ensemble`.

Currently, we're preserving both the refactored `EnsembleFrame` API and the `Ensemble` API, so with this change I also update several unit tests to be parameterized to use both the refactored and 'legacy' methods (both `Ensemble.compute` and `EnsembleFrame.compute`, both`Ensemble.dropna` and `EnsembleFrame.dropna`, etc.) This is a bit awkward, and should be removed once the old API is deprecated.