### PR TITLE
Update Remaining TAPE Documentation Notebooks for the Refactor

### DIFF
--- a/docs/tutorials/binning_slowly_changing_sources.ipynb
+++ b/docs/tutorials/binning_slowly_changing_sources.ipynb
@@ -60,7 +60,7 @@
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(1, 1)\n",
-    "ax.hist(ens._source[\"midPointTai\"].compute().tolist(), 500)\n",
+    "ax.hist(ens.source[\"midPointTai\"].compute().tolist(), 500)\n",
     "ax.set_xlabel(\"Time (MJD)\")\n",
     "ax.set_ylabel(\"Source Count\")"
    ]
@@ -90,7 +90,7 @@
    "source": [
     "ens.bin_sources(time_window=7.0, offset=0.0)\n",
     "fig, ax = plt.subplots(1, 1)\n",
-    "ax.hist(ens._source[\"midPointTai\"].compute().tolist(), 500)\n",
+    "ax.hist(ens.source[\"midPointTai\"].compute().tolist(), 500)\n",
     "ax.set_xlabel(\"Time (MJD)\")\n",
     "ax.set_ylabel(\"Source Count\")"
    ]
@@ -120,7 +120,7 @@
    "source": [
     "ens.bin_sources(time_window=28.0, offset=0.0, custom_aggr={\"midPointTai\": \"min\"})\n",
     "fig, ax = plt.subplots(1, 1)\n",
-    "ax.hist(ens._source[\"midPointTai\"].compute().tolist(), 500)\n",
+    "ax.hist(ens.source[\"midPointTai\"].compute().tolist(), 500)\n",
     "ax.set_xlabel(\"Time (MJD)\")\n",
     "ax.set_ylabel(\"Source Count\")"
    ]
@@ -150,7 +150,7 @@
     "ens.from_source_dict(rows, column_mapper=cmap)\n",
     "\n",
     "fig, ax = plt.subplots(1, 1)\n",
-    "ax.hist(ens._source[\"midPointTai\"].compute().tolist(), 60)\n",
+    "ax.hist(ens.source[\"midPointTai\"].compute().tolist(), 60)\n",
     "ax.set_xlabel(\"Time (MJD)\")\n",
     "ax.set_ylabel(\"Source Count\")"
    ]
@@ -179,7 +179,7 @@
     "ens.bin_sources(time_window=1.0, offset=0.0)\n",
     "\n",
     "fig, ax = plt.subplots(1, 1)\n",
-    "ax.hist(ens._source[\"midPointTai\"].compute().tolist(), 60)\n",
+    "ax.hist(ens.source[\"midPointTai\"].compute().tolist(), 60)\n",
     "ax.set_xlabel(\"Time (MJD)\")\n",
     "ax.set_ylabel(\"Source Count\")"
    ]
@@ -209,7 +209,7 @@
     "ens.bin_sources(time_window=1.0, offset=0.5)\n",
     "\n",
     "fig, ax = plt.subplots(1, 1)\n",
-    "ax.hist(ens._source[\"midPointTai\"].compute().tolist(), 60)\n",
+    "ax.hist(ens.source[\"midPointTai\"].compute().tolist(), 60)\n",
     "ax.set_xlabel(\"Time (MJD)\")\n",
     "ax.set_ylabel(\"Source Count\")"
    ]
@@ -259,7 +259,7 @@
     "ens.bin_sources(time_window=1.0, offset=0.5)\n",
     "\n",
     "fig, ax = plt.subplots(1, 1)\n",
-    "ax.hist(ens._source[\"midPointTai\"].compute().tolist(), 60)\n",
+    "ax.hist(ens.source[\"midPointTai\"].compute().tolist(), 60)\n",
     "ax.set_xlabel(\"Time (MJD)\")\n",
     "ax.set_ylabel(\"Source Count\")"
    ]
@@ -290,7 +290,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.13"
   },
   "vscode": {
    "interpreter": {

--- a/docs/tutorials/scaling_to_large_data.ipynb
+++ b/docs/tutorials/scaling_to_large_data.ipynb
@@ -216,7 +216,7 @@
     "\n",
     "print(\"number of lightcurve results in mapres: \", len(mapres))\n",
     "print(\"number of lightcurve results in groupres: \", len(groupres))\n",
-    "print(\"True number of lightcurves in the dataset:\", len(np.unique(ens._source.index)))"
+    "print(\"True number of lightcurves in the dataset:\", len(np.unique(ens.source.index)))"
    ]
   },
   {
@@ -263,7 +263,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.13"
   },
   "vscode": {
    "interpreter": {

--- a/docs/tutorials/structure_function_showcase.ipynb
+++ b/docs/tutorials/structure_function_showcase.ipynb
@@ -267,7 +267,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ens.head(\"object\", 5)  \n"
+    "ens.head.object(5)  \n"
    ]
   },
   {
@@ -276,7 +276,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ens.head(\"source\", 5)  "
+    "ens.source.head(5)  "
    ]
   },
   {

--- a/docs/tutorials/structure_function_showcase.ipynb
+++ b/docs/tutorials/structure_function_showcase.ipynb
@@ -267,7 +267,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ens.head.object(5)  \n"
+    "ens.object.head(5)  \n"
    ]
   },
   {

--- a/docs/tutorials/tape_datasets.ipynb
+++ b/docs/tutorials/tape_datasets.ipynb
@@ -52,7 +52,7 @@
     "                 column_mapper=col_map\n",
     "                )\n",
     "\n",
-    "ens.head(\"source\") # View the first 5 entries of the source table"
+    "ens.source.head(5) # View the first 5 entries of the source table"
    ]
   },
   {
@@ -93,7 +93,7 @@
     "                 column_mapper=col_map\n",
     "                )\n",
     "\n",
-    "ens.head(\"object\") # View the first 5 entries of the object table"
+    "ens.object.head(5) # View the first 5 entries of the object table"
    ]
   },
   {
@@ -168,7 +168,7 @@
    "source": [
     "ens.from_dataset(\"s82_rrlyrae\")  # Let's grab the Stripe 82 RR Lyrae\n",
     "\n",
-    "ens.head(\"object\", 5)"
+    "ens.object.head(5)"
    ]
   },
   {
@@ -270,7 +270,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.13"
   },
   "vscode": {
    "interpreter": {

--- a/docs/tutorials/using_ray_with_the_ensemble.ipynb
+++ b/docs/tutorials/using_ray_with_the_ensemble.ipynb
@@ -81,7 +81,7 @@
    "outputs": [],
    "source": [
     "ens.from_dataset(\"s82_qso\")\n",
-    "ens._source = ens._source.repartition(npartitions=10)\n",
+    "ens.source = ens.source.repartition(npartitions=10)\n",
     "ens.batch(calc_sf2, use_map=False)  # use_map is false as we repartition naively, splitting per-object sources across partitions"
    ]
   },
@@ -116,7 +116,7 @@
     "\n",
     "ens=Ensemble(client=False) # Do not use a client\n",
     "ens.from_dataset(\"s82_qso\")\n",
-    "ens._source = ens._source.repartition(npartitions=10)\n",
+    "ens.source = ens.source.repartition(npartitions=10)\n",
     "ens.batch(calc_sf2, use_map=False)"
    ]
   },
@@ -150,7 +150,7 @@
     "\n",
     "ens = Ensemble()\n",
     "ens.from_dataset(\"s82_qso\")\n",
-    "ens._source = ens._source.repartition(npartitions=10)\n",
+    "ens.source = ens.source.repartition(npartitions=10)\n",
     "ens.batch(calc_sf2, use_map=False)"
    ]
   }
@@ -171,7 +171,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.13"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Updates remaining TAPE documentation notebooks for the refactor, primarily consisting of replacing references to `Ensemble._source` and `Ensemble._object` with `Ensemble.source` and `Ensemble.object` respectively. No changes to the structure or functionality of the notebooks are made.