### PR TITLE
Add version

### DIFF
--- a/src/tape/__init__.py
+++ b/src/tape/__init__.py
@@ -2,3 +2,4 @@ from .analysis import *  # noqa
 from .ensemble import *  # noqa
 from .timeseries import *  # noqa
 from .ensemble_readers import *  # noqa
+from ._version import __version__  # noqa

--- a/tests/tape_tests/test_packaging.py
+++ b/tests/tape_tests/test_packaging.py
@@ -1,0 +1,6 @@
+import tape
+
+
+def test_version():
+    """Check to see that the version property returns something"""
+    assert tape.__version__ is not None


### PR DESCRIPTION
Addresses #137, looks like we were just missing the one line in the init, as setuptools already dynamically generates a _version.py file.

(Should be completely non-conflicting with the refactor)