### PR TITLE
Fix table syncing to use inner joins.

### DIFF
--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -1550,8 +1550,8 @@ class Ensemble:
                 # Lazily Create an empty object table (just index) for joining
                 empty_obj = self._object.map_partitions(lambda x: pd.DataFrame(index=x.index))
 
-                # Join source onto the empty object table to align
-                self._source = empty_obj.join(self._source)
+                # Join source onto the empty object table to remove IDs not present in both tables
+                self._source = self._source.join(empty_obj, how='inner')
             else:
                 warnings.warn("Divisions are not known, syncing using a non-lazy method.")
                 obj_idx = list(self._object.index.compute())
@@ -1570,8 +1570,9 @@ class Ensemble:
                     # Lazily Create an empty source table (just unique indexes) for joining
                     empty_src = self._source.map_partitions(lambda x: pd.DataFrame(index=x.index.unique()))
 
-                    # Join object onto the empty unique source table to align
-                    self._object = empty_src.join(self._object)
+                    # Join object onto the empty unique source table to remove IDs not present in
+                    # both tables
+                    self._object = self._object.join(empty_src, how='inner')
 
                 else:
                     warnings.warn("Divisions are not known, syncing using a non-lazy method.")

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -1551,7 +1551,7 @@ class Ensemble:
                 empty_obj = self._object.map_partitions(lambda x: pd.DataFrame(index=x.index))
 
                 # Join source onto the empty object table to remove IDs not present in both tables
-                self._source = self._source.join(empty_obj, how='inner')
+                self._source = self._source.join(empty_obj, how="inner")
             else:
                 warnings.warn("Divisions are not known, syncing using a non-lazy method.")
                 obj_idx = list(self._object.index.compute())
@@ -1572,7 +1572,7 @@ class Ensemble:
 
                     # Join object onto the empty unique source table to remove IDs not present in
                     # both tables
-                    self._object = self._object.join(empty_src, how='inner')
+                    self._object = self._object.join(empty_src, how="inner")
 
                 else:
                     warnings.warn("Divisions are not known, syncing using a non-lazy method.")


### PR DESCRIPTION
In https://github.com/lincc-frameworks/tape/pull/283, we introduced logic to allow for lazy syncing of tables with known divisions. This was accomplished via a [`join`](https://docs.dask.org/en/stable/generated/dask.dataframe.DataFrame.join.html) call which was a left join by default.

However since we always sync the object table before the source table, it's possible to create an arrangement of operations values removed from the source table's index can be synced back from a dirty object table. This PR updates `test_ensemble.test_sync_tables` to have such a failing case and fixes it by switching to inner joins.