### PR TITLE
Adds a random lightcurve selection function to the Ensemble

### DIFF
--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -1870,10 +1870,8 @@ class Ensemble:
         in larger partitions.
 
         """
-        if seed is not None:
-            rng = np.random.default_rng(seed)
-        else:
-            rng = np.random
+
+        rng = np.random.default_rng(seed)
 
         # We will select one partition at random to select an object from
         partitions = np.array(range(self.object.npartitions))

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -1847,6 +1847,36 @@ class Ensemble:
         self.object.set_dirty(False)
         return self
 
+    def select_random_timeseries(self, seed=None):
+        """Selects a random lightcurve from the Ensemble
+
+        Parameters
+        ----------
+        seed: int, or None
+            Sets a seed to return the same object id on successive runs. `None`
+            by default, in which case a seed is not set for the operation.
+
+        Returns
+        -------
+        ts: `TimeSeries`
+            Timeseries for a single object
+
+        """
+
+        if seed is not None:
+            np.random.seed(seed)
+
+        # Avoid a choice from full index space, select a random partition to grab from
+        if self.object.npartitions > 1:
+            partition_num = np.random.randint(0, self.object.npartitions - 1)
+            partition_ids = self.object.get_partition(partition_num).index.values
+            lcid = np.random.choice(partition_ids)
+        else:
+            partition_num = 0
+            lcid = np.random.choice(self.object.index.values)
+        print(f"Selected Object {lcid} from Partition {partition_num}")
+        return self.to_timeseries(lcid)
+
     def to_timeseries(
         self,
         target,

--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -1891,9 +1891,8 @@ class Ensemble:
                 print(f"Selected Object {lcid} from Partition {partitions[i]}")
                 object_selected = True
             else:
-                print(f"skipped empty partition: {partitions[i]}")
                 i += 1
-                if i > len(partitions):
+                if i >= len(partitions):
                     raise IndexError("Found no object IDs in the Object Table.")
 
         return self.to_timeseries(lcid)

--- a/tests/tape_tests/test_ensemble.py
+++ b/tests/tape_tests/test_ensemble.py
@@ -17,6 +17,7 @@ from tape import (
     TapeSeries,
     TapeObjectFrame,
     TapeSourceFrame,
+    TimeSeries,
 )
 from tape.analysis.stetsonj import calc_stetson_J
 from tape.analysis.structure_function.base_argument_container import StructureFunctionArgumentContainer
@@ -1827,6 +1828,26 @@ def test_batch_with_custom_frame_meta(parquet_ensemble, custom_meta):
     assert len(parquet_ensemble.frames) == num_frames + 1
     assert len(parquet_ensemble.select_frame("sf2_result")) > 0
     assert isinstance(parquet_ensemble.select_frame("sf2_result"), EnsembleFrame)
+
+
+@pytest.mark.parametrize("repartition", [False, True])
+@pytest.mark.parametrize("seed", [None, 42])
+def test_select_random_timeseries(parquet_ensemble, repartition, seed):
+    """Test the behavior of ensemble.select_random_timeseries"""
+
+    ens = parquet_ensemble
+
+    if repartition:
+        ens.object = ens.object.repartition(3)
+
+    ts = ens.select_random_timeseries(seed=seed)
+
+    assert isinstance(ts, TimeSeries)
+
+    if seed == 42 and not repartition:
+        assert ts.meta["id"] == 88480000587403327
+    elif seed == 42 and repartition:
+        assert ts.meta["id"] == 88480000310609896
 
 
 def test_to_timeseries(parquet_ensemble):

--- a/tests/tape_tests/test_ensemble.py
+++ b/tests/tape_tests/test_ensemble.py
@@ -1845,9 +1845,46 @@ def test_select_random_timeseries(parquet_ensemble, repartition, seed):
     assert isinstance(ts, TimeSeries)
 
     if seed == 42 and not repartition:
-        assert ts.meta["id"] == 88480000587403327
+        assert ts.meta["id"] == 88472935274829959
     elif seed == 42 and repartition:
-        assert ts.meta["id"] == 88480000310609896
+        assert ts.meta["id"] == 88480001333818899
+
+
+@pytest.mark.parametrize("all_empty", [False, True])
+def test_select_random_timeseries_empty_partitions(dask_client, all_empty):
+    "Test the edge case where object has empty partitions"
+
+    data_dict = {
+        "id": [42],
+        "flux": [1],
+        "time": [1],
+        "err": [1],
+        "band": [1],
+    }
+
+    colmap = ColumnMapper().assign(
+        id_col="id",
+        time_col="time",
+        flux_col="flux",
+        err_col="err",
+        band_col="band",
+    )
+
+    ens = Ensemble(client=dask_client)
+    ens.from_source_dict(data_dict, column_mapper=colmap)
+
+    # The single id will be in the last partition
+    ens.object = ens.object.repartition(5)
+
+    # Remove the last partition, make sure we get the expected error when the
+    # Object table has no IDs in any partition
+    if all_empty:
+        ens.object = ens.object.partitions[0:-1]
+        with pytest.raises(IndexError):
+            ens.select_random_timeseries()
+    else:
+        ts = ens.select_random_timeseries()
+        assert ts.meta["id"] == 42  # Should always find the only object
 
 
 def test_to_timeseries(parquet_ensemble):


### PR DESCRIPTION
Resolves #332.

Adds a convenience function to grab a random lightcurve from the Ensemble, which we expect users to use to do quick sanity checks that operations have had the desired effect on their lightcurves.