### PR TITLE
Fix EnsembleFrame.repartition

### DIFF
--- a/src/tape/ensemble.py
+++ b/src/tape/ensemble.py
@@ -336,7 +336,7 @@ class Ensemble:
             if all(prev_div):
                 self.update_frame(self.source.repartition(divisions=prev_div))
             elif self.source.npartitions != prev_num:
-                self.source = self.source.repartition(npartitions=prev_num)
+                self.update_frame(self.source.repartition(npartitions=prev_num))
 
         return self
 

--- a/src/tape/ensemble_frame.py
+++ b/src/tape/ensemble_frame.py
@@ -675,7 +675,7 @@ class _Frame(dd.core._Frame):
         force=False,
     ):
         """Repartition dataframe along new divisions
-        
+
         Doc string below derived from dask.dataframe.DataFrame
 
         Parameters
@@ -733,10 +733,10 @@ class _Frame(dd.core._Frame):
         >>> df = df.repartition(freq='7d')  # doctest: +SKIP
         """
         result = super().repartition(
-            divisions=divisions, 
-            npartitions=npartitions, 
+            divisions=divisions,
+            npartitions=npartitions,
             partition_size=partition_size,
-            freq=freq, 
+            freq=freq,
             force=force,
         )
         return self._propagate_metadata(result)

--- a/src/tape/ensemble_frame.py
+++ b/src/tape/ensemble_frame.py
@@ -666,7 +666,14 @@ class _Frame(dd.core._Frame):
             self.ensemble._lazy_sync_tables_from_frame(self)
         return super().compute(**kwargs)
 
-    def repartition(self, **kwargs):
+    def repartition(
+        self,
+        divisions=None,
+        npartitions=None,
+        partition_size=None,
+        freq=None,
+        force=False,
+    ):
         """Repartition dataframe along new divisions
         
         Doc string below derived from dask.dataframe.DataFrame
@@ -725,7 +732,13 @@ class _Frame(dd.core._Frame):
         >>> df = df.repartition(divisions=[0, 5, 10, 20])  # doctest: +SKIP
         >>> df = df.repartition(freq='7d')  # doctest: +SKIP
         """
-        result = super().repartition(**kwargs)
+        result = super().repartition(
+            divisions=divisions, 
+            npartitions=npartitions, 
+            partition_size=partition_size,
+            freq=freq, 
+            force=force,
+        )
         return self._propagate_metadata(result)
 
 

--- a/src/tape/ensemble_frame.py
+++ b/src/tape/ensemble_frame.py
@@ -666,6 +666,68 @@ class _Frame(dd.core._Frame):
             self.ensemble._lazy_sync_tables_from_frame(self)
         return super().compute(**kwargs)
 
+    def repartition(self, **kwargs):
+        """Repartition dataframe along new divisions
+        
+        Doc string below derived from dask.dataframe.DataFrame
+
+        Parameters
+        ----------
+        divisions : list, optional
+            The "dividing lines" used to split the dataframe into partitions.
+            For ``divisions=[0, 10, 50, 100]``, there would be three output partitions,
+            where the new index contained [0, 10), [10, 50), and [50, 100), respectively.
+            See https://docs.dask.org/en/latest/dataframe-design.html#partitions.
+            Only used if npartitions and partition_size isn't specified.
+            For convenience if given an integer this will defer to npartitions
+            and if given a string it will defer to partition_size (see below)
+        npartitions : int, optional
+            Approximate number of partitions of output. Only used if partition_size
+            isn't specified. The number of partitions used may be slightly
+            lower than npartitions depending on data distribution, but will never be
+            higher.
+        partition_size: int or string, optional
+            Max number of bytes of memory for each partition. Use numbers or
+            strings like 5MB. If specified npartitions and divisions will be
+            ignored. Note that the size reflects the number of bytes used as
+            computed by ``pandas.DataFrame.memory_usage``, which will not
+            necessarily match the size when storing to disk.
+
+            .. warning::
+
+               This keyword argument triggers computation to determine
+               the memory size of each partition, which may be expensive.
+
+        freq : str, pd.Timedelta
+            A period on which to partition timeseries data like ``'7D'`` or
+            ``'12h'`` or ``pd.Timedelta(hours=12)``.  Assumes a datetime index.
+        force : bool, default False
+            Allows the expansion of the existing divisions.
+            If False then the new divisions' lower and upper bounds must be
+            the same as the old divisions'.
+
+        Notes
+        -----
+        Exactly one of `divisions`, `npartitions`, `partition_size`, or `freq`
+        should be specified. A ``ValueError`` will be raised when that is
+        not the case.
+
+        Also note that ``len(divisons)`` is equal to ``npartitions + 1``. This is because ``divisions``
+        represents the upper and lower bounds of each partition. The first item is the
+        lower bound of the first partition, the second item is the lower bound of the
+        second partition and the upper bound of the first partition, and so on.
+        The second-to-last item is the lower bound of the last partition, and the last
+        (extra) item is the upper bound of the last partition.
+
+        Examples
+        --------
+        >>> df = df.repartition(npartitions=10)  # doctest: +SKIP
+        >>> df = df.repartition(divisions=[0, 5, 10, 20])  # doctest: +SKIP
+        >>> df = df.repartition(freq='7d')  # doctest: +SKIP
+        """
+        result = super().repartition(**kwargs)
+        return self._propagate_metadata(result)
+
 
 class TapeSeries(pd.Series):
     """A barebones extension of a Pandas series to be used for underlying Ensemble data.

--- a/tests/tape_tests/test_ensemble_frame.py
+++ b/tests/tape_tests/test_ensemble_frame.py
@@ -143,6 +143,13 @@ def test_ensemble_frame_propagation(data_fixture, request):
     assert merged_frame.ensemble == ens
     assert merged_frame.is_dirty()
 
+    # Test that frame metadata is preserved after repartitioning
+    repartitioned_frame = ens_frame.copy().repartition(npartitions=10)
+    assert isinstance(repartitioned_frame, EnsembleFrame)
+    assert repartitioned_frame.label == TEST_LABEL
+    assert repartitioned_frame.ensemble == ens
+    assert repartitioned_frame.is_dirty()
+
     # Test that head returns a subset of the underlying TapeFrame.
     h = ens_frame.head(5)
     assert isinstance(h, TapeFrame)


### PR DESCRIPTION
## Change Description
`EnsembleFrame` now extends Dask's [`DataFrame.repartition`](https://docs.dask.org/en/stable/generated/dask.dataframe.DataFrame.repartition.html) to ensure that Ensemble-related metadata is propagated. This closes https://github.com/lincc-frameworks/tape/issues/342

I also replace a call to 

```self.source = self.source.repartition(...)```

with 

```self.update_frame(self.source.repartition(...)``` to ensure that all frame-related tracking data is updated.

- [x] My PR includes a link to the issue that I am addressing

## Code Quality
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
- [ ] I have added a function that requires a sync_tables command, and have added the neccesary sync_tables call

### Bug Fix Checklist
- [x] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)