### PR TITLE
Pin Dask dependency to avoid dask-expr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dynamic=["version"]
 dependencies = [
     'pandas',
     'numpy',
-    'dask>=2023.6.1',
+    'dask>=2023.6.1,<2024.3.0', # We currently do not support dask/dask-expr
     'dask[distributed]',
     'pyarrow',
     'pyvo',


### PR DESCRIPTION
As noted in https://github.com/lincc-frameworks/tape/issues/382, we currently do not support dask-expr as a backend, however it became the default Dask backend with the release of Dask 2024.3.0 (See https://github.com/dask/community/issues/366)

Here we pin Dask to be in a range below this version until dask-expr support is fully added.

### Build/CI Change Checklist
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the README to reflect this
- [ ] If this is a new CI setup, I have added the associated badge to the README