### PR TITLE
Remotes/origin/wilsonbb patch 3

### DIFF
--- a/docs/tutorials/working_with_hipscat_and_lsdb.ipynb
+++ b/docs/tutorials/working_with_hipscat_and_lsdb.ipynb
@@ -175,7 +175,7 @@
     "object_cat_cone = object_cat.cone_search(\n",
     "    ra=315.0,\n",
     "    dec=-69.5,\n",
-    "    radius=10.0,\n",
+    "    radius_arcsec=10.0,\n",
     ")\n",
     "\n",
     "print(f\"Original Number of Objects: {len(object_cat._ddf)}\")\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dynamic=["version"]
 dependencies = [
     'pandas',
     'numpy',
-    'dask>=2023.6.1',
+    'dask>=2023.6.1,<2024.3.0', # We currently do not support dask/dask-expr
     'dask[distributed]',
     'pyarrow',
     'pyvo',


### PR DESCRIPTION
As noted in https://github.com/lincc-frameworks/tape/issues/382, we currently do not support dask-expr as a backend, however it became the default Dask backend with the release of Dask 2024.3.0 (See https://github.com/dask/community/issues/366)

Here we pin Dask to be in a range below this version until dask-expr support is fully added.

Additionally in the LSDB notebook, we update the [`cone_search`](https://github.com/astronomy-commons/lsdb/blob/d4ca0a67ab76453cce51ab1fddf873cf5e128173/src/lsdb/catalog/catalog.py#L194) call to use the new `radius_arcsec` argument (formerly just `radius`)