### PR TITLE
Minor docs cleanups for TAPE 

### DIFF
--- a/docs/gettingstarted/quickstart.ipynb
+++ b/docs/gettingstarted/quickstart.ipynb
@@ -21,7 +21,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install lf-tape"
+    "%pip install lf-tape"
    ]
   },
   {

--- a/docs/gettingstarted/quickstart.ipynb
+++ b/docs/gettingstarted/quickstart.ipynb
@@ -12,12 +12,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The latest release of TAPE is installable via pip, using the following command:\n",
-    "\n",
-    "```\n",
-    "pip install lf-tape\n",
-    "```\n",
-    "\n",
+    "The latest release of TAPE is installable via pip, using the following command:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install lf-tape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "For more detailed installation instructions, see the [Installation Guide](installation.html)."
    ]
   },
@@ -200,7 +210,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   },
   "vscode": {
    "interpreter": {

--- a/docs/tutorials/common_data_operations.ipynb
+++ b/docs/tutorials/common_data_operations.ipynb
@@ -143,7 +143,7 @@
     "\n",
     "If you'd like to access a particular lightcurve given an ID, you can use the `to_timeseries()` function. This allows you to supply a given object ID, and returns a `TimeSeries` object (see [working_with_the_timeseries](working_with_the_timeseries.ipynb)).\n",
     "\n",
-    "Note taht this loads data from all available bands."
+    "Note that this loads data from all available bands."
    ]
   },
   {
@@ -498,7 +498,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For reproducible results, you can also specify a random seed via the `random_state` parameter. This should ensure that an `Ensemble` will always be sampled the same way."
+    "For reproducible results, you can also specify a random seed via the `random_state` parameter. By re-using the same seed in your `random_state`, you can ensure that a given `Ensemble` will always be sampled the same way."
    ]
   },
   {

--- a/docs/tutorials/common_data_operations.ipynb
+++ b/docs/tutorials/common_data_operations.ipynb
@@ -141,7 +141,9 @@
    "source": [
     "### Access using a known ID\n",
     "\n",
-    "If you'd like to access a particular lightcurve given an ID, you can use the `to_timeseries()` function. This allows you to supply a given object ID, and returns a `TimeSeries` object (see [working_with_the_timeseries](working_with_the_timeseries.ipynb))."
+    "If you'd like to access a particular lightcurve given an ID, you can use the `to_timeseries()` function. This allows you to supply a given object ID, and returns a `TimeSeries` object (see [working_with_the_timeseries](working_with_the_timeseries.ipynb)).\n",
+    "\n",
+    "Note taht this loads data from all available bands."
    ]
   },
   {
@@ -493,6 +495,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For reproducible results, you can also specify a random seed via the `random_state` parameter. This should ensure that an `Ensemble` will always be sampled the same way."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subset_ens = ens.sample(\n",
+    "    frac=0.2,  # select a ~fifth of the objects\n",
+    "    random_state=53783594,  # set a random seed for reproducibility\n",
+    ")\n",
+    "\n",
+    "print(\"Number of pre-sampled objects: \", len(ens.object))\n",
+    "print(\"Number of post-sampled objects: \", len(subset_ens.object))"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -569,7 +593,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.14"
   },
   "vscode": {
    "interpreter": {

--- a/docs/tutorials/common_data_operations.ipynb
+++ b/docs/tutorials/common_data_operations.ipynb
@@ -143,7 +143,8 @@
     "\n",
     "If you'd like to access a particular lightcurve given an ID, you can use the `to_timeseries()` function. This allows you to supply a given object ID, and returns a `TimeSeries` object (see [working_with_the_timeseries](working_with_the_timeseries.ipynb)).\n",
     "\n",
-    "Note that this loads data from all available bands."
+    "> **_Note:_**\n",
+    "that this loads data from all available bands."
    ]
   },
   {

--- a/docs/tutorials/working_with_the_timeseries.ipynb
+++ b/docs/tutorials/working_with_the_timeseries.ipynb
@@ -54,11 +54,22 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ts.data[ts.band == \"r\"].psFlux"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As a result, we get a multi-indexed `Pandas` DataFrame with data from a single lightcurve. The multi-index contains a band index as well as a integer index. We can operate on this as we normally would a `Pandas` DataFrame."
+    "As a result, we get a multi-indexed `Pandas` DataFrame with data from a single lightcurve. The multi-index contains a band index as well as a integer index. We can operate on this as we normally would a `Pandas` DataFrame.\n",
+    "\n",
+    "Below we plot out the g-band of the lightcurve."
    ]
   },
   {
@@ -69,9 +80,15 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "ts_r = ts.data[ts.band == \"r\"]\n",
     "\n",
-    "plt.plot(ts_r[\"midPointTai\"], ts_r[\"psFlux\"])"
+    "ts_g = ts.data[ts.band == \"g\"]\n",
+    "\n",
+    "plt.figure(figsize=(8, 5))\n",
+    "plt.errorbar(ts_g.midPointTai, ts_g.psFlux, ts_g.psFluxErr, fmt=\"o\", color=\"green\", alpha=0.8, label=\"g\")\n",
+    "plt.xlabel(\"Time (MJD)\")\n",
+    "plt.ylabel(\"Flux (mJy)\")\n",
+    "plt.minorticks_on()\n",
+    "plt.legend(title=\"Band\", loc=\"upper left\")"
    ]
   }
  ],
@@ -91,7 +108,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.14"
   },
   "vscode": {
    "interpreter": {

--- a/docs/tutorials/working_with_the_timeseries.ipynb
+++ b/docs/tutorials/working_with_the_timeseries.ipynb
@@ -54,15 +54,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ts.data[ts.band == \"r\"].psFlux"
-   ]
-  },
-  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},


### PR DESCRIPTION
A series of minor docs cleanups addressing small changes proposed in https://github.com/lincc-frameworks/tape/issues/372

The following changes are made:

* When loading a time series object in what was formerly [ this section](https://tape.readthedocs.io/en/latest/tutorials/working_with_the_ensemble.html#Inspection), add a sentence such as ``Note that this loads the data from all available bands’’
* Changed ``Installing`` in the Quickstart to be an executable shell command to pip install TAPE
* Demonstrate setting a random seed in `Ensemble.smaple`
* Improves the plot in in[ From the ensemble](https://tape.readthedocs.io/en/latest/tutorials/working_with_the_timeseries.html#From-the-Ensemble)


- [x] My PR includes a link to the issue that I am addressing