### PR TITLE
Have head() traverse all partitions

### DIFF
--- a/docs/tutorials/common_data_operations.ipynb
+++ b/docs/tutorials/common_data_operations.ipynb
@@ -110,7 +110,7 @@
     "Often, you'll want to peek at your data even though the full-size is too large for memory.\n",
     "\n",
     "> **_Note:_**\n",
-    "By default this only looks at the first partition of data, so any operations that remove all data from the first partition will produce an empty head result. Specify `npartitions=-1` to grab from all partitions.\n"
+    "some partitions may be empty and `head` will have to traverse these empty partitions to find enough rows for your result. An empty table with many partitions (O(100)k) might be costly even for an ultimately empty result. "
    ]
   },
   {
@@ -119,7 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ens.source.head(5, npartitions=-1)  # grabs the first 5 rows\n",
+    "ens.source.head(5)  # grabs the first 5 rows\n",
     "\n",
     "# can also use tail to grab the last 5 rows"
    ]

--- a/src/tape/ensemble_frame.py
+++ b/src/tape/ensemble_frame.py
@@ -845,7 +845,7 @@ class _Frame(dx.FrameBase):
         )
         return self._propagate_metadata(result)
 
-    def head(self, n=5, compute=True):
+    def head(self, n=5, compute=True, npartitions=None):
         """Returns `n` rows of data for previewing purposes.
 
         Parameters
@@ -854,10 +854,17 @@ class _Frame(dx.FrameBase):
             The number of desired rows. Default is 5.
         compute : bool, optional
             Whether to compute the result immediately. Default is True.
+        npartitions : int, optional
+            `npartitions` is not supported and if provided will be ignored. Instead all partitions may be used.
 
         Returns:
             A pandas DataFrame with up to `n` rows of data.
         """
+        if npartitions is not None:
+            warnings.warn(
+                "The 'npartitions' parameter is not supported for TAPE dataframes. All partitions may be used."
+            )
+
         if not compute:
             # Just use the Dask head method
             return super().head(n, compute=False)

--- a/tests/tape_tests/test_ensemble_frame.py
+++ b/tests/tape_tests/test_ensemble_frame.py
@@ -492,6 +492,10 @@ def test_head(data_fixture, request):
 
     assert frame.npartitions == 10
 
+    # Check that a warning is raised when npartitions are requested.
+    with pytest.warns(UserWarning):
+        frame.head(5, npartitions=5)
+
     # Test inputs that should return an empty frame
     assert len(frame.head(-100)) == 0
     assert len(frame.head(0)) == 0

--- a/tests/tape_tests/test_ensemble_frame.py
+++ b/tests/tape_tests/test_ensemble_frame.py
@@ -497,6 +497,8 @@ def test_head(data_fixture, request):
     assert len(frame.head(0)) == 0
     assert len(frame.head(-1)) == 0
 
+    assert len(frame.head(100, compute=False).compute()) == 100
+
     one_res = frame.head(1)
     assert len(one_res) == 1
     assert isinstance(one_res, TapeFrame)

--- a/tests/tape_tests/test_ensemble_frame.py
+++ b/tests/tape_tests/test_ensemble_frame.py
@@ -472,6 +472,7 @@ def test_partition_slicing(parquet_ensemble_with_divisions):
     assert ens.source.npartitions == 2  # should return exactly 2 partitions
     assert len(ens.object) < prior_src_len  # should affect objects
 
+
 @pytest.mark.parametrize(
     "data_fixture",
     [
@@ -522,4 +523,3 @@ def test_head(data_fixture, request):
     assert len(result) == rows
     assert isinstance(result, TapeFrame)
     assert set(result.columns) == set(frame.columns)
-

--- a/tests/tape_tests/test_ensemble_frame.py
+++ b/tests/tape_tests/test_ensemble_frame.py
@@ -1,5 +1,6 @@
 """ Test EnsembleFrame (inherited from Dask.DataFrame) creation and manipulations. """
 
+from math import floor
 import numpy as np
 import pandas as pd
 from tape import (
@@ -440,3 +441,55 @@ def test_partition_slicing(parquet_ensemble_with_divisions):
 
     assert ens.source.npartitions == 2  # should return exactly 2 partitions
     assert len(ens.object) < prior_src_len  # should affect objects
+
+@pytest.mark.parametrize(
+    "data_fixture",
+    [
+        "parquet_ensemble",
+        "parquet_ensemble_with_divisions",
+    ],
+)
+def test_head(data_fixture, request):
+    """
+    Tests that head returns the correct number of rows.
+    """
+    ens = request.getfixturevalue(data_fixture)
+
+    # Test witht repartitioning the source frame
+    frame = ens.source
+    frame = frame.repartition(npartitions=10)
+
+    assert frame.npartitions == 10
+
+    # Test inputs that should return an empty frame
+    assert len(frame.head(-100)) == 0
+    assert len(frame.head(0)) == 0
+    assert len(frame.head(-1)) == 0
+
+    one_res = frame.head(1)
+    assert len(one_res) == 1
+    assert isinstance(one_res, TapeFrame)
+    assert set(one_res.columns) == set(frame.columns)
+
+    def_result = frame.head()
+    assert len(def_result) == 5
+    assert isinstance(one_res, TapeFrame)
+    assert set(one_res.columns) == set(frame.columns)
+
+    def_result = frame.head(24)
+    assert len(def_result) == 24
+    assert isinstance(one_res, TapeFrame)
+    assert set(one_res.columns) == set(frame.columns)
+
+    # Test that we have sane behavior even when the number of rows requested is larger than the number of rows in the frame.
+    assert len(frame.head(2 * len(frame))) == len(frame)
+
+    # Choose a value that will be guaranteed to hit every partition for this data.
+    # Note that with parquet_ensemble_with_divisions some of the partitions are empty
+    # testing that as well.
+    rows = floor(len(frame.compute()) * 0.98)
+    result = frame.head(rows)
+    assert len(result) == rows
+    assert isinstance(result, TapeFrame)
+    assert set(result.columns) == set(frame.columns)
+


### PR DESCRIPTION
As was pointed out in https://github.com/lincc-frameworks/tape/issues/380, it is not uncommon for partitions to be empty, which can lead to unintuitive results for users since `head` by default only looks at the first partitions.  

To make `head(n)` more intuitive for users we can have it search across all partitions stopping only once there are `n` rows to return.  This differs from Dask behavior where a user must explicitly choose how many partitions to search across.

Warning: this removes the `npartitions` argument previously available in `EnsembleFrame.head` 

- [x] My PR includes a link to the issue that I am addressing

## Solution Description
Here we iterate over each partition similar to how `head()` until we have found enough rows similar to the [implementation in LSDB](https://github.com/astronomy-commons/lsdb/blob/12271382ee6953c32d4422f0e777d05c0d1bd8f0/src/lsdb/catalog/catalog.py#L70)

## Code Quality
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

### New Feature Checklist
- [x] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have updated the tutorial to highlight my new feature (if appropriate)
- [x] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [x] My change includes a breaking change
  - [x] My change includes backwards compatibility and deprecation warnings (if possible)