### PR TITLE
Add support for running batch on a single lightcurve

### DIFF
--- a/docs/tutorials/batch_showcase.ipynb
+++ b/docs/tutorials/batch_showcase.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,30 +57,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/wilsonbb/lincc/tape/test_batch/tape/tape/src/tape/ensemble.py:1676: UserWarning: Divisions for object are not set, certain downstream dask operations may fail as a result. We recommend setting the `sort` or `sorted` flags when loading data to establish division information.\n",
-      "  warnings.warn(\n",
-      "/Users/wilsonbb/lincc/tape/test_batch/tape/tape/src/tape/ensemble.py:1676: UserWarning: Divisions for source are not set, certain downstream dask operations may fail as a result. We recommend setting the `sort` or `sorted` flags when loading data to establish division information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<tape.ensemble.Ensemble at 0x2a6ec3d90>"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Load the data into an Ensemble\n",
     "ens = Ensemble()\n",
@@ -94,98 +73,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>mjd</th>\n",
-       "      <th>flux</th>\n",
-       "      <th>err</th>\n",
-       "      <th>band</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>id</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>109</th>\n",
-       "      <td>1245.0</td>\n",
-       "      <td>8.360253</td>\n",
-       "      <td>0.836025</td>\n",
-       "      <td>g</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>109</th>\n",
-       "      <td>1246.0</td>\n",
-       "      <td>3.892404</td>\n",
-       "      <td>0.389240</td>\n",
-       "      <td>g</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>109</th>\n",
-       "      <td>1247.0</td>\n",
-       "      <td>0.751697</td>\n",
-       "      <td>0.075170</td>\n",
-       "      <td>r</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>109</th>\n",
-       "      <td>1248.0</td>\n",
-       "      <td>4.082942</td>\n",
-       "      <td>0.408294</td>\n",
-       "      <td>g</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>109</th>\n",
-       "      <td>1249.0</td>\n",
-       "      <td>6.122806</td>\n",
-       "      <td>0.612281</td>\n",
-       "      <td>g</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "        mjd      flux       err band\n",
-       "id                                  \n",
-       "109  1245.0  8.360253  0.836025    g\n",
-       "109  1246.0  3.892404  0.389240    g\n",
-       "109  1247.0  0.751697  0.075170    r\n",
-       "109  1248.0  4.082942  0.408294    g\n",
-       "109  1249.0  6.122806  0.612281    g"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ens.source.tail(5)"
    ]
@@ -208,20 +98,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3.0"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Case 1: Simple\n",
     "def my_mean(flux):\n",
@@ -241,117 +120,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Using generated label, result_1, for a batch result.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>result</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>id</th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>5.020567</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>11</th>\n",
-       "      <td>5.041076</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12</th>\n",
-       "      <td>4.916761</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13</th>\n",
-       "      <td>5.033744</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>14</th>\n",
-       "      <td>5.084872</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>105</th>\n",
-       "      <td>5.113830</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>106</th>\n",
-       "      <td>5.097340</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>107</th>\n",
-       "      <td>5.013111</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>108</th>\n",
-       "      <td>4.962582</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>109</th>\n",
-       "      <td>5.143362</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>100 rows × 1 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "       result\n",
-       "id           \n",
-       "10   5.020567\n",
-       "11   5.041076\n",
-       "12   4.916761\n",
-       "13   5.033744\n",
-       "14   5.084872\n",
-       "..        ...\n",
-       "105  5.113830\n",
-       "106  5.097340\n",
-       "107  5.013111\n",
-       "108  4.962582\n",
-       "109  5.143362\n",
-       "\n",
-       "[100 rows x 1 columns]"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Default batch\n",
     "res1 = ens.batch(\n",
@@ -359,6 +130,13 @@
     ")  # \"flux\" is provided to have TAPE pass the \"flux\" column data along to my_mean\n",
     "res1.compute()  # Compute to see the result"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -369,68 +147,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Using generated label, result_7, for a batch result.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>result</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>id</th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>109</th>\n",
-       "      <td>5.143362</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "       result\n",
-       "id           \n",
-       "109  5.143362"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# The same batch call as above but now only on the final lightcurve.\n",
     "\n",
-    "lc_id = 109\n",
+    "lc_id = 109  # id of the final lightcurve in the data\n",
     "lc_res = ens.batch(my_mean, \"flux\", single_lc=lc_id)\n",
     "lc_res.compute()"
    ]

--- a/docs/tutorials/batch_showcase.ipynb
+++ b/docs/tutorials/batch_showcase.ipynb
@@ -72,15 +72,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ens.source.tail(5)"
-   ]
-  },
-  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -132,17 +123,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default `Ensemble.batch` will apply your function across all light curves. However with the `single_lc` parameter you can test out your function only on a single object."
+    "By default `Ensemble.batch` will apply your function across all light curves. However with the `single_lc` parameter you can test out your function on only a single object."
    ]
   },
   {

--- a/docs/tutorials/batch_showcase.ipynb
+++ b/docs/tutorials/batch_showcase.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,9 +57,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/wilsonbb/lincc/tape/test_batch/tape/tape/src/tape/ensemble.py:1676: UserWarning: Divisions for object are not set, certain downstream dask operations may fail as a result. We recommend setting the `sort` or `sorted` flags when loading data to establish division information.\n",
+      "  warnings.warn(\n",
+      "/Users/wilsonbb/lincc/tape/test_batch/tape/tape/src/tape/ensemble.py:1676: UserWarning: Divisions for source are not set, certain downstream dask operations may fail as a result. We recommend setting the `sort` or `sorted` flags when loading data to establish division information.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<tape.ensemble.Ensemble at 0x2a6ec3d90>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Load the data into an Ensemble\n",
     "ens = Ensemble()\n",
@@ -68,6 +89,104 @@
     "    source_dict,\n",
     "    column_mapper=ColumnMapper(id_col=\"id\", time_col=\"mjd\", flux_col=\"flux\", err_col=\"err\", band_col=\"band\"),\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mjd</th>\n",
+       "      <th>flux</th>\n",
+       "      <th>err</th>\n",
+       "      <th>band</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>109</th>\n",
+       "      <td>1245.0</td>\n",
+       "      <td>8.360253</td>\n",
+       "      <td>0.836025</td>\n",
+       "      <td>g</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>109</th>\n",
+       "      <td>1246.0</td>\n",
+       "      <td>3.892404</td>\n",
+       "      <td>0.389240</td>\n",
+       "      <td>g</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>109</th>\n",
+       "      <td>1247.0</td>\n",
+       "      <td>0.751697</td>\n",
+       "      <td>0.075170</td>\n",
+       "      <td>r</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>109</th>\n",
+       "      <td>1248.0</td>\n",
+       "      <td>4.082942</td>\n",
+       "      <td>0.408294</td>\n",
+       "      <td>g</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>109</th>\n",
+       "      <td>1249.0</td>\n",
+       "      <td>6.122806</td>\n",
+       "      <td>0.612281</td>\n",
+       "      <td>g</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        mjd      flux       err band\n",
+       "id                                  \n",
+       "109  1245.0  8.360253  0.836025    g\n",
+       "109  1246.0  3.892404  0.389240    g\n",
+       "109  1247.0  0.751697  0.075170    r\n",
+       "109  1248.0  4.082942  0.408294    g\n",
+       "109  1249.0  6.122806  0.612281    g"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ens.source.tail(5)"
    ]
   },
   {
@@ -88,9 +207,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.0"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Case 1: Simple\n",
     "def my_mean(flux):\n",
@@ -110,15 +240,198 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using generated label, result_1, for a batch result.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>result</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>id</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>5.020567</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>5.041076</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>4.916761</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>5.033744</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>5.084872</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>105</th>\n",
+       "      <td>5.113830</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>106</th>\n",
+       "      <td>5.097340</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>107</th>\n",
+       "      <td>5.013111</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>108</th>\n",
+       "      <td>4.962582</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>109</th>\n",
+       "      <td>5.143362</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>100 rows × 1 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       result\n",
+       "id           \n",
+       "10   5.020567\n",
+       "11   5.041076\n",
+       "12   4.916761\n",
+       "13   5.033744\n",
+       "14   5.084872\n",
+       "..        ...\n",
+       "105  5.113830\n",
+       "106  5.097340\n",
+       "107  5.013111\n",
+       "108  4.962582\n",
+       "109  5.143362\n",
+       "\n",
+       "[100 rows x 1 columns]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Default batch\n",
     "res1 = ens.batch(\n",
     "    my_mean, \"flux\"\n",
     ")  # \"flux\" is provided to have TAPE pass the \"flux\" column data along to my_mean\n",
     "res1.compute()  # Compute to see the result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default `Ensemble.batch` will apply your function across all light curves. However with the `single_lc` parameter you can test out your function only on a single object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using generated label, result_7, for a batch result.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>result</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>id</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>109</th>\n",
+       "      <td>5.143362</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       result\n",
+       "id           \n",
+       "109  5.143362"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The same batch call as above but now only on the final lightcurve.\n",
+    "\n",
+    "lc_id = 109\n",
+    "lc_res = ens.batch(my_mean, \"flux\", single_lc=lc_id)\n",
+    "lc_res.compute()"
    ]
   },
   {
@@ -584,7 +897,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.14"
   },
   "vscode": {
    "interpreter": {

--- a/docs/tutorials/batch_showcase.ipynb
+++ b/docs/tutorials/batch_showcase.ipynb
@@ -144,6 +144,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also run your batch function on a single random lightcurve with `single_lc=True`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rand_lc = ens.batch(my_mean, \"flux\", single_lc=True)\n",
+    "rand_lc.compute()"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},

--- a/tests/tape_tests/test_ensemble.py
+++ b/tests/tape_tests/test_ensemble.py
@@ -2134,7 +2134,12 @@ def test_batch_single_lc(data_fixture, request):
     """
     parquet_ensemble = request.getfixturevalue(data_fixture)
 
+    # Perform batch only on this specific lightcurve.
     lc = 88472935274829959
+
+    # Check that we raise an error if single_lc is neither a bool nor an integer
+    with pytest.raises(ValueError):
+        parquet_ensemble.batch(calc_stetson_J, use_map=True, on=None, band_to_calc=None, single_lc="foo")
 
     lc_res = parquet_ensemble.prune(10).batch(
         calc_stetson_J, use_map=True, on=None, band_to_calc=None, single_lc=lc
@@ -2144,6 +2149,22 @@ def test_batch_single_lc(data_fixture, request):
     # Now ensure that we got the same result when we ran the function on the entire ensemble.
     full_res = parquet_ensemble.prune(10).batch(calc_stetson_J, use_map=True, on=None, band_to_calc=None)
     assert full_res.compute().loc[lc].stetsonJ == lc_res.compute().iloc[0].stetsonJ
+
+    # Check that when single_lc is True we will perform batch on a random lightcurve and still get only one result.
+    rand_lc = parquet_ensemble.prune(10).batch(
+        calc_stetson_J, use_map=True, on=None, band_to_calc=None, single_lc=True
+    )
+    assert len(rand_lc) == 1
+
+    # Now compare that result to what was computed when doing the full batch result
+    rand_lc_id = rand_lc.index.compute().values[0]
+    assert full_res.compute().loc[rand_lc_id].stetsonJ == rand_lc.compute().iloc[0].stetsonJ
+
+    # Check that when single_lc is False we get the same # of results as the full batch
+    no_lc = parquet_ensemble.prune(10).batch(
+        calc_stetson_J, use_map=True, on=None, band_to_calc=None, single_lc=False
+    )
+    assert len(full_res) == len(no_lc)
 
 
 def test_batch_labels(parquet_ensemble):
@@ -2255,7 +2276,8 @@ def test_batch_with_custom_frame_meta(parquet_ensemble, custom_meta):
 
 @pytest.mark.parametrize("repartition", [False, True])
 @pytest.mark.parametrize("seed", [None, 42])
-def test_select_random_timeseries(parquet_ensemble, repartition, seed):
+@pytest.mark.parametrize("id_only", [True, False])
+def test_select_random_timeseries(parquet_ensemble, repartition, seed, id_only):
     """Test the behavior of ensemble.select_random_timeseries"""
 
     ens = parquet_ensemble
@@ -2263,14 +2285,17 @@ def test_select_random_timeseries(parquet_ensemble, repartition, seed):
     if repartition:
         ens.object = ens.object.repartition(npartitions=3)
 
-    ts = ens.select_random_timeseries(seed=seed)
+    ts = ens.select_random_timeseries(seed=seed, id_only=id_only)
 
-    assert isinstance(ts, TimeSeries)
+    if not id_only:
+        assert isinstance(ts, TimeSeries)
 
-    if seed == 42 and not repartition:
-        assert ts.meta["id"] == 88472935274829959
-    elif seed == 42 and repartition:
-        assert ts.meta["id"] == 88480001333818899
+    if seed == 42:
+        expected_id = 88480001333818899 if repartition else 88472935274829959
+        if id_only:
+            assert ts == expected_id
+        else:
+            assert ts.meta["id"] == expected_id
 
 
 @pytest.mark.parametrize("all_empty", [False, True])

--- a/tests/tape_tests/test_ensemble.py
+++ b/tests/tape_tests/test_ensemble.py
@@ -2127,6 +2127,25 @@ def test_batch_by_band(parquet_ensemble, func_label, on):
     assert all([col in res.columns for col in res.compute().columns])
 
 
+@pytest.mark.parametrize("data_fixture", ["parquet_ensemble", "parquet_ensemble_with_divisions"])
+def test_batch_single_lc(data_fixture, request):
+    """
+    Test that ensemble.batch() can run a function on a single light curve.
+    """
+    parquet_ensemble = request.getfixturevalue(data_fixture)
+
+    lc = 88472935274829959
+
+    lc_res = parquet_ensemble.prune(10).batch(
+        calc_stetson_J, use_map=True, on=None, band_to_calc=None, single_lc=lc
+    )
+    assert len(lc_res) == 1
+
+    # Now ensure that we got the same result when we ran the function on the entire ensemble.
+    full_res = parquet_ensemble.prune(10).batch(calc_stetson_J, use_map=True, on=None, band_to_calc=None)
+    assert full_res.compute().loc[lc].stetsonJ == lc_res.compute().iloc[0].stetsonJ
+
+
 def test_batch_labels(parquet_ensemble):
     """
     Test that ensemble.batch() generates unique labels for result frames when none are provided.


### PR DESCRIPTION
## Change Description
In https://github.com/lincc-frameworks/tape/issues/409 it was proposed to add a batch helper function `try_batch` which would allow `Ensemble.batch` to be tested on a single lightcurve. To accomplish that goal, here we instead add a new parameter `single_lc` to `Ensemble.batch`

When `single_lc` is provided an object ID, the function provided to `batch` is executed on that single lightcurve.
- [x] My PR includes a link to the issue that I am addressing

## Code Quality
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation


### New Feature Checklist
- [x] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have updated the tutorial to highlight my new feature (if appropriate)
- [x] I have added unit/End-to-End (E2E) test cases to cover my new feature