### PR TITLE
quiet the quickstart pip install

### DIFF
--- a/docs/gettingstarted/quickstart.ipynb
+++ b/docs/gettingstarted/quickstart.ipynb
@@ -21,7 +21,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install lf-tape"
+    "\n",
+    "%pip install lf-tape --quiet\n"
    ]
   },
   {
@@ -210,7 +211,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.11"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
I noticed that the pip install command in the quickstart guide has a lot of output (potentially because we now use the magic command?). To address this, I've added the quiet flag. Alternatively we could opt to return to using `!pip install lf-tape`


