### PR TITLE
limit depth of toctrees

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -4,5 +4,6 @@ Examples
 Some examples of how to use the TAPE package are provided in these notebooks.
 
 .. toctree::
+    :maxdepth: 1
 
     Use Lomb–Scargle Periodograms for SDSS Stripe 82 RR Lyrae <examples/rrlyr-period>

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -6,6 +6,7 @@ we encourage you to open an issue on the
 `TAPE github repository <https://github.com/lincc-frameworks/tape/issues>`_.
 
 .. toctree::
+    :maxdepth: 1
 
     Installing TAPE <gettingstarted/installation>
     Quickstart Guide <gettingstarted/quickstart>

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -5,6 +5,7 @@ These pages contain a set of tutorial notebooks for working through core and mor
 functionality.
 
 .. toctree::
+    :maxdepth: 1
 
     Loading Data into TAPE <tutorials/tape_datasets>
     Working with the TAPE Ensemble object <tutorials/working_with_the_ensemble>


### PR DESCRIPTION
Improves the table of contents view for each of our documentation subsections by just displaying the sections, rather than a full list of all subsections.
